### PR TITLE
Fix: sync bug where users loose changes

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -118,6 +118,8 @@ export interface FrontierAPI {
         hasConflicts: boolean;
         conflicts?: Array<ConflictedFile>;
         offline?: boolean;
+        allChangedFilePaths?: string[];
+        remoteChangedFilePaths?: string[];
     }>;
     completeMerge: (
         resolvedFiles: ResolvedFile[],

--- a/src/scm/SCMManager.ts
+++ b/src/scm/SCMManager.ts
@@ -382,7 +382,15 @@ export class SCMManager {
     async syncChanges(
         options?: { commitMessage?: string },
         isManualSync: boolean = false
-    ): Promise<{ hasConflicts: boolean; conflicts?: ConflictedFile[] }> {
+    ): Promise<{
+        hasConflicts: boolean;
+        conflicts?: ConflictedFile[];
+        /**
+         * Optional diagnostics to help clients validate remote changes vs merged conflicts.
+         */
+        allChangedFilePaths?: string[];
+        remoteChangedFilePaths?: string[];
+    }> {
         // Check extension version compatibility with project metadata before syncing
         const canSync = await checkMetadataVersionsForSync(this.context, isManualSync);
         if (!canSync) {
@@ -588,6 +596,8 @@ export class SCMManager {
                 return {
                     hasConflicts: true,
                     conflicts: syncResult.conflicts,
+                    allChangedFilePaths: syncResult.allChangedFilePaths,
+                    remoteChangedFilePaths: syncResult.remoteChangedFilePaths,
                 };
             }
 


### PR DESCRIPTION
…stics

- Added `allChangedFilePaths` and `remoteChangedFilePaths` to the `SyncResult` and `SCMManager.syncChanges` return types for improved conflict resolution diagnostics.
- Updated the conflict detection logic to identify files added in both branches, enhancing the merge conflict handling capabilities.
- Introduced a new integration test to verify the detection of conflicts for files added in both branches.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Enhances conflict detection and exposes diagnostics**
> 
> - Adds `allChangedFilePaths` and `remoteChangedFilePaths` to `SyncResult` and `SCMManager.syncChanges` and returns them from `GitService.syncChanges`
> - Improves divergent-history analysis to detect files added on both sides (e.g., `.codex`) and treat them as conflicts; computes and logs categorized file sets
> - Updates `extension.ts` API typings for `syncChanges` to include the new diagnostics
> - Adds an integration test validating conflicts for files added in both branches
> - Minor type/formatting cleanups in `GitService` (auth shapes, loop/style fixes)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b9b0e3b9eecfeb2d72685877483dbe64a5403a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->