### PR TITLE
617 archived projects listed

### DIFF
--- a/src/commands/scmCommands.ts
+++ b/src/commands/scmCommands.ts
@@ -44,6 +44,7 @@ export function registerSCMCommands(
                     name: project.name,
                     description: project.description,
                     visibility: project.visibility,
+                    isArchived: project.isArchived ?? false,
                     url: project.http_url_to_repo,
                     webUrl: project.web_url,
                     lastActivity: project.last_activity_at,

--- a/src/commands/scmCommands.ts
+++ b/src/commands/scmCommands.ts
@@ -44,7 +44,7 @@ export function registerSCMCommands(
                     name: project.name,
                     description: project.description,
                     visibility: project.visibility,
-                    isArchived: project.isArchived ?? false,
+                    isArchived: project.archived ?? false,
                     url: project.http_url_to_repo,
                     webUrl: project.web_url,
                     lastActivity: project.last_activity_at,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,6 +43,7 @@ export interface FrontierAPI {
             name: string;
             description: string | null;
             visibility: string;
+            isArchived?: boolean;
             url: string;
             webUrl: string;
             lastActivity: string;
@@ -264,6 +265,7 @@ export async function activate(context: vscode.ExtensionContext) {
                     name: string;
                     description: string | null;
                     visibility: string;
+                    isArchived?: boolean;
                     url: string;
                     webUrl: string;
                     lastActivity: string;

--- a/src/gitlab/GitLabService.ts
+++ b/src/gitlab/GitLabService.ts
@@ -30,7 +30,7 @@ interface GitLabProject {
     name: string;
     description: string | null;
     visibility: "private" | "internal" | "public";
-    isArchived?: boolean;
+    archived?: boolean;
     http_url_to_repo: string;
     web_url: string;
     created_at: string;

--- a/src/gitlab/GitLabService.ts
+++ b/src/gitlab/GitLabService.ts
@@ -30,6 +30,7 @@ interface GitLabProject {
     name: string;
     description: string | null;
     visibility: "private" | "internal" | "public";
+    isArchived?: boolean;
     http_url_to_repo: string;
     web_url: string;
     created_at: string;


### PR DESCRIPTION
This coincides with issue 617 in the codex repo. It serves to allow us to have access to whether a project is archived in gitlab or not. You will need this in order to see the results for the project list in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit ff24e8a4e9b83da854273001beafa5e4c1cf9606. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->