### PR TITLE
Vscodeignore dist directory exclusion

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -5,6 +5,7 @@
 */**
 
 # Webpack output (extension.js + askpass helper)
+!dist/
 !dist/**
 
 # Extension manifest and metadata


### PR DESCRIPTION
Fix `.vscodeignore` to correctly include the `dist` directory.

The previous pattern `*` ignored the `dist` directory, which prevented `!dist/**` from re-including its contents, making the packaged extension non-functional.

---