### PR TITLE
Signal sync completion for Codex Conductor pin detection

### DIFF
--- a/src/scm/SCMManager.ts
+++ b/src/scm/SCMManager.ts
@@ -666,6 +666,10 @@ export class SCMManager {
                     status: "completed",
                     message: "Synchronization complete",
                 });
+                // Signal to the Codex Conductor that a sync completed.
+                // The conductor observes this via IStorageService to detect
+                // mid-session pin changes in metadata.json.
+                this.context.workspaceState.update('syncCompletedAt', Date.now());
             }
         }
     }


### PR DESCRIPTION
Write `syncCompletedAt` timestamp to `workspaceState` after successful sync.

The Codex Conductor (a workbench contribution in the Codex shell) needs to detect when `metadata.json` pins change mid-session. Since the conductor runs on the main thread and cannot access extension APIs, it observes Frontier's `workspaceState` via `IStorageService.onDidChangeValue`. This one-line addition provides that signal.

See arch doc: https://github.com/genesis-ai-dev/codex-arch/blob/main/2026-03-project-extension-pinning.md#mid-session-pin-detection

## Changes

- Write `syncCompletedAt` to `workspaceState` in `SCMManager.syncChanges()` after a successful sync completes

## Test plan

- [ ] Verify sync still works normally — no behavior change
- [ ] Verify `workspaceState` contains `syncCompletedAt` after a successful sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single `workspaceState` update after successful sync with no change to sync logic or data flow beyond writing a timestamp.
> 
> **Overview**
> Writes a `syncCompletedAt` timestamp to VS Code `workspaceState` when `SCMManager.syncChanges()` completes successfully, providing an observable signal (via `IStorageService`) for the Codex Conductor to detect mid-session `metadata.json` pin changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b956ba947e0429838816b5d16355e8901f8fa38. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->