### PR TITLE
Write syncCompletedAt signal after sync for Codex Conductor pin detection

### DIFF
--- a/src/scm/SCMManager.ts
+++ b/src/scm/SCMManager.ts
@@ -666,6 +666,10 @@ export class SCMManager {
                     status: "completed",
                     message: "Synchronization complete",
                 });
+                // Signal to the Codex Conductor that a sync completed.
+                // The conductor observes this via IStorageService to detect
+                // mid-session pin changes in metadata.json.
+                await this.context.workspaceState.update('syncCompletedAt', Date.now());
             }
         }
     }


### PR DESCRIPTION
Writes a `syncCompletedAt` timestamp to workspace storage after SCM sync completes,
enabling Codex Conductor to detect mid-session project changes for extension pin evaluation.

See [Extension Version Pinning architecture doc](https://github.com/genesis-ai-dev/codex-arch/blob/main/2026-03-project-extension-pinning.md) for full design context.

## Changes
- Add `syncCompletedAt` signal write in `SCMManager.ts` after successful sync