### PR TITLE
Implement pin-aware sync gate for Codex Conductor extension pinning

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(pnpm run:*)",
+      "Bash(curl:*)",
+      "Bash(node -e \":*)",
+      "Bash(./dev/build.sh -s)"
+    ]
+  }
+}

--- a/src/scm/SCMManager.ts
+++ b/src/scm/SCMManager.ts
@@ -15,6 +15,7 @@ import {
     getInstalledExtensionVersions,
     handleOutdatedExtensionsForSync,
     ExtensionVersionInfo,
+    checkPinnedExtensionsForSync,
 } from "../utils/extensionVersionChecker";
 
 export class SCMManager {
@@ -415,6 +416,20 @@ export class SCMManager {
         });
     }
 
+    private async handleRemotePinValidation(
+        remotePins: Record<string, { version: string; url: string }> | undefined,
+        isManualSync: boolean
+    ): Promise<{ canSync: boolean; pinnedIds: Set<string> }> {
+        // Write remote pins to workspaceState so the Codex Conductor
+        // (workbench contribution) can pick them up via IStorageService,
+        // even if sync aborts before merge lands metadata.json on disk.
+        await this.context.workspaceState.update("remotePinnedExtensions", remotePins);
+
+        // Use the shared utility to check for mismatches, respect cooldowns, and show notifications.
+        // This ensures remote pin detection behaves exactly like the local sync-gate.
+        return await checkPinnedExtensionsForSync(this.context, isManualSync, remotePins);
+    }
+
     async syncChanges(
         options?: { commitMessage?: string },
         isManualSync: boolean = false
@@ -526,8 +541,18 @@ export class SCMManager {
                                         codexEditor?: string;
                                         frontierAuthentication?: string;
                                     };
+                                    pinnedExtensions?: Record<string, { version: string; url: string }>;
                                 };
                             };
+
+                            // Write remote pins to workspaceState and check for mismatches.
+                            // Pins override requiredExtensions version checks.
+                            const remotePins = remoteMetadata.meta?.pinnedExtensions;
+                            const { canSync: canSyncPins, pinnedIds } =
+                                await this.handleRemotePinValidation(remotePins, isManualSync);
+                            if (!canSyncPins) {
+                                return { hasConflicts: false };
+                            }
 
                             const required = remoteMetadata.meta?.requiredExtensions;
                             if (required) {
@@ -538,6 +563,7 @@ export class SCMManager {
                                 if (
                                     required.codexEditor &&
                                     codexEditorVersion &&
+                                    !pinnedIds.has("project-accelerate.codex-editor-extension") &&
                                     compareVersions(codexEditorVersion, required.codexEditor) < 0
                                 ) {
                                     outdated.push({
@@ -553,6 +579,7 @@ export class SCMManager {
                                 if (
                                     required.frontierAuthentication &&
                                     frontierAuthVersion &&
+                                    !pinnedIds.has("frontier-rnd.frontier-authentication") &&
                                     compareVersions(
                                         frontierAuthVersion,
                                         required.frontierAuthentication

--- a/src/scm/SCMManager.ts
+++ b/src/scm/SCMManager.ts
@@ -666,6 +666,10 @@ export class SCMManager {
                     status: "completed",
                     message: "Synchronization complete",
                 });
+                // Signal to the Codex Conductor that a sync completed.
+                // The conductor observes this via IStorageService to detect
+                // mid-session pin changes in metadata.json.
+                await this.context.workspaceState.update('syncCompletedAt', Date.now());
             }
         }
     }

--- a/src/scm/SCMManager.ts
+++ b/src/scm/SCMManager.ts
@@ -16,6 +16,7 @@ import {
     handleOutdatedExtensionsForSync,
     ExtensionVersionInfo,
     checkPinnedExtensionsForSync,
+    readLocalPinnedExtensions,
 } from "../utils/extensionVersionChecker";
 
 export class SCMManager {
@@ -117,9 +118,58 @@ export class SCMManager {
             )
         );
 
+        // Push pin update command (admin-only) - bypasses remote pin checks
+        this.context.subscriptions.push(
+            vscode.commands.registerCommand(
+                "frontier.pushPinUpdate",
+                (options?: { commitMessage?: string }) =>
+                    this.syncChanges(
+                        { ...options, ignoreRemotePins: true },
+                        true
+                    )
+            )
+        );
+
         // Toggle auto-sync command
         this.context.subscriptions.push(
             vscode.commands.registerCommand("frontier.toggleAutoSync", () => this.toggleAutoSync())
+        );
+
+        // Set admin pin intent - used by the Codex Conductor when an admin applies a pin change locally
+        this.context.subscriptions.push(
+            vscode.commands.registerCommand(
+                "frontier.setAdminPinIntent",
+                (pins: Record<string, { version: string; url: string }>) =>
+                    this.context.workspaceState.update("adminPinnedExtensions", pins)
+            )
+        );
+
+        // Clear admin pin intent - used to manually clear the intent override
+        this.context.subscriptions.push(
+            vscode.commands.registerCommand("frontier.clearAdminPinIntent", () =>
+                this.context.workspaceState.update("adminPinnedExtensions", undefined)
+            )
+        );
+
+        // Get remote pinned extensions
+        this.context.subscriptions.push(
+            vscode.commands.registerCommand("frontier.getRemotePinnedExtensions", () =>
+                this.context.workspaceState.get<Record<string, { version: string; url: string }>>(
+                    "remotePinnedExtensions"
+                )
+            )
+        );
+
+        // Get full remote pinned extensions state (including admin intent)
+        this.context.subscriptions.push(
+            vscode.commands.registerCommand("frontier.getRemotePinnedExtensionsState", () => ({
+                remotePinnedExtensions: this.context.workspaceState.get<
+                    Record<string, { version: string; url: string }>
+                >("remotePinnedExtensions"),
+                adminPinnedExtensions: this.context.workspaceState.get<
+                    Record<string, { version: string; url: string }>
+                >("adminPinnedExtensions"),
+            }))
         );
 
         // Commit changes command (used by SCM input box)
@@ -418,7 +468,8 @@ export class SCMManager {
 
     private async handleRemotePinValidation(
         remotePins: Record<string, { version: string; url: string }> | undefined,
-        isManualSync: boolean
+        isManualSync: boolean,
+        options?: { ignoreRemotePins?: boolean }
     ): Promise<{ canSync: boolean; pinnedIds: Set<string> }> {
         // Write remote pins to workspaceState so the Codex Conductor
         // (workbench contribution) can pick them up via IStorageService,
@@ -427,11 +478,11 @@ export class SCMManager {
 
         // Use the shared utility to check for mismatches, respect cooldowns, and show notifications.
         // This ensures remote pin detection behaves exactly like the local sync-gate.
-        return await checkPinnedExtensionsForSync(this.context, isManualSync, remotePins);
+        return await checkPinnedExtensionsForSync(this.context, isManualSync, remotePins, options);
     }
 
     async syncChanges(
-        options?: { commitMessage?: string },
+        options?: { commitMessage?: string; ignoreRemotePins?: boolean },
         isManualSync: boolean = false
     ): Promise<{
         hasConflicts: boolean;
@@ -443,7 +494,7 @@ export class SCMManager {
         remoteChangedFilePaths?: string[];
     }> {
         // Check extension version compatibility with project metadata before syncing
-        const canSync = await checkMetadataVersionsForSync(this.context, isManualSync);
+        const canSync = await checkMetadataVersionsForSync(this.context, isManualSync, options);
         if (!canSync) {
             return { hasConflicts: false };
         }
@@ -549,7 +600,7 @@ export class SCMManager {
                             // Pins override requiredExtensions version checks.
                             const remotePins = remoteMetadata.meta?.pinnedExtensions;
                             const { canSync: canSyncPins, pinnedIds } =
-                                await this.handleRemotePinValidation(remotePins, isManualSync);
+                                await this.handleRemotePinValidation(remotePins, isManualSync, options);
                             if (!canSyncPins) {
                                 return { hasConflicts: false };
                             }
@@ -708,9 +759,19 @@ export class SCMManager {
                     status: "completed",
                     message: "Synchronization complete",
                 });
-                // Signal to the Codex Conductor that a sync completed.
-                // The conductor observes this via IStorageService to detect
-                // mid-session pin changes in metadata.json.
+                
+                // After a successful sync (fetch -> merge -> push), the local and remote
+                // states are converged. We refresh remotePinnedExtensions storage to match
+                // what we just pushed, ensuring the Conductor sees the latest pins on next reload.
+                try {
+                    const convergedPins = await readLocalPinnedExtensions();
+                    await this.context.workspaceState.update("remotePinnedExtensions", convergedPins);
+                } catch (e) {
+                    console.error("[SCMManager] Failed to refresh remote pins after sync:", e);
+                }
+
+                // Clear the admin intent (override) since the change is now authoritative on the remote.
+                await this.context.workspaceState.update("adminPinnedExtensions", undefined);
                 await this.context.workspaceState.update('syncCompletedAt', Date.now());
             }
         }

--- a/src/scm/SCMManager.ts
+++ b/src/scm/SCMManager.ts
@@ -16,6 +16,7 @@ import {
     handleOutdatedExtensionsForSync,
     ExtensionVersionInfo,
     checkPinnedExtensionsForSync,
+    findPinMismatches,
 } from "../utils/extensionVersionChecker";
 
 export class SCMManager {

--- a/src/scm/SCMManager.ts
+++ b/src/scm/SCMManager.ts
@@ -99,7 +99,7 @@ export class SCMManager {
             const settingsPath = path.join(workspacePath, ".project", "localProjectSettings.json");
             const content = await fs.promises.readFile(settingsPath, "utf8");
             const settings = JSON.parse(content);
-            if (!settings.lfsSourceRemoteUrl) return;
+            if (!settings.lfsSourceRemoteUrl) { return; }
             delete settings.lfsSourceRemoteUrl;
             await fs.promises.writeFile(settingsPath, JSON.stringify(settings, null, 4));
         } catch {

--- a/src/scm/SCMManager.ts
+++ b/src/scm/SCMManager.ts
@@ -11,12 +11,11 @@ import { ResolvedFile } from "../extension";
 import { MediaFilesStrategy } from "../types/state";
 import { checkMetadataVersionsForSync } from "../utils/extensionVersionChecker";
 import {
-    compareVersions,
+    checkRequiredVersion,
     getInstalledExtensionVersions,
     handleOutdatedExtensionsForSync,
     ExtensionVersionInfo,
     checkPinnedExtensionsForSync,
-    findPinMismatches,
 } from "../utils/extensionVersionChecker";
 
 export class SCMManager {
@@ -563,13 +562,22 @@ export class SCMManager {
 
                                 if (
                                     required.codexEditor &&
-                                    codexEditorVersion &&
                                     !pinnedIds.has("project-accelerate.codex-editor-extension") &&
-                                    compareVersions(codexEditorVersion, required.codexEditor) < 0
+                                    (() => {
+                                        const codexCheck = checkRequiredVersion(
+                                            codexEditorVersion,
+                                            required.codexEditor,
+                                            "Codex Editor"
+                                        );
+                                        return (
+                                            codexCheck.kind === "unknown_current" ||
+                                            (codexCheck.kind === "ok" && codexCheck.comparison < 0)
+                                        );
+                                    })()
                                 ) {
                                     outdated.push({
                                         extensionId: "project-accelerate.codex-editor-extension",
-                                        currentVersion: codexEditorVersion,
+                                        currentVersion: codexEditorVersion ?? "unknown",
                                         latestVersion: required.codexEditor,
                                         isOutdated: true,
                                         downloadUrl: "",
@@ -579,16 +587,22 @@ export class SCMManager {
 
                                 if (
                                     required.frontierAuthentication &&
-                                    frontierAuthVersion &&
                                     !pinnedIds.has("frontier-rnd.frontier-authentication") &&
-                                    compareVersions(
-                                        frontierAuthVersion,
-                                        required.frontierAuthentication
-                                    ) < 0
+                                    (() => {
+                                        const frontierCheck = checkRequiredVersion(
+                                            frontierAuthVersion,
+                                            required.frontierAuthentication,
+                                            "Frontier Authentication"
+                                        );
+                                        return (
+                                            frontierCheck.kind === "unknown_current" ||
+                                            (frontierCheck.kind === "ok" && frontierCheck.comparison < 0)
+                                        );
+                                    })()
                                 ) {
                                     outdated.push({
                                         extensionId: "frontier-rnd.frontier-authentication",
-                                        currentVersion: frontierAuthVersion,
+                                        currentVersion: frontierAuthVersion ?? "unknown",
                                         latestVersion: required.frontierAuthentication,
                                         isOutdated: true,
                                         downloadUrl: "",

--- a/src/scm/SCMManager.ts
+++ b/src/scm/SCMManager.ts
@@ -15,7 +15,7 @@ import {
     getInstalledExtensionVersions,
     handleOutdatedExtensionsForSync,
     ExtensionVersionInfo,
-    checkPinnedExtensionsForSync,
+    checkEffectivePinsAfterFetch,
     readLocalPinnedExtensions,
 } from "../utils/extensionVersionChecker";
 
@@ -468,17 +468,16 @@ export class SCMManager {
 
     private async handleRemotePinValidation(
         remotePins: Record<string, { version: string; url: string }> | undefined,
-        isManualSync: boolean,
-        options?: { ignoreRemotePins?: boolean }
+        isManualSync: boolean
     ): Promise<{ canSync: boolean; pinnedIds: Set<string> }> {
         // Write remote pins to workspaceState so the Codex Conductor
         // (workbench contribution) can pick them up via IStorageService,
         // even if sync aborts before merge lands metadata.json on disk.
         await this.context.workspaceState.update("remotePinnedExtensions", remotePins);
 
-        // Use the shared utility to check for mismatches, respect cooldowns, and show notifications.
-        // This ensures remote pin detection behaves exactly like the local sync-gate.
-        return await checkPinnedExtensionsForSync(this.context, isManualSync, remotePins, options);
+        // Now ask the Conductor for effective pins — it sees the just-written
+        // remote pins via IStorageService and resolves them with correct priority.
+        return await checkEffectivePinsAfterFetch(this.context, isManualSync);
     }
 
     async syncChanges(
@@ -596,11 +595,11 @@ export class SCMManager {
                                 };
                             };
 
-                            // Write remote pins to workspaceState and check for mismatches.
-                            // Pins override requiredExtensions version checks.
+                            // Write remote pins to workspaceState, then ask the Conductor
+                            // for effective pins (which now include the just-fetched remote pins).
                             const remotePins = remoteMetadata.meta?.pinnedExtensions;
                             const { canSync: canSyncPins, pinnedIds } =
-                                await this.handleRemotePinValidation(remotePins, isManualSync, options);
+                                await this.handleRemotePinValidation(remotePins, isManualSync);
                             if (!canSyncPins) {
                                 return { hasConflicts: false };
                             }

--- a/src/test/suite/integration/versionChecker.test.ts
+++ b/src/test/suite/integration/versionChecker.test.ts
@@ -6,6 +6,7 @@ import {
     handleOutdatedExtensionsForSync,
     buildOutdatedExtensionsMessage,
     ExtensionVersionInfo,
+    checkRequiredVersion,
 } from "../../../utils/extensionVersionChecker";
 
 suite("Integration: extensionVersionChecker", () => {
@@ -85,6 +86,31 @@ suite("Integration: extensionVersionChecker", () => {
         const expected = buildOutdatedExtensionsMessage(outdated);
         assert.strictEqual(shownMessage, expected);
     });
+
+    test("malformed required version fails open without showing a toast", () => {
+        let shownMessage: string | undefined;
+        (vscode.window.showWarningMessage as any) = async (msg: string) => {
+            shownMessage = msg;
+            return undefined;
+        };
+
+        const result = checkRequiredVersion(
+            "0.24.1-pr123",
+            "not-a-version",
+            "Codex Editor"
+        );
+
+        assert.deepStrictEqual(result, { kind: "invalid_required" });
+        assert.strictEqual(shownMessage, undefined);
+    });
+
+    test("valid required version with missing installed version fails closed", () => {
+        const result = checkRequiredVersion(
+            null,
+            "0.24.1",
+            "Codex Editor"
+        );
+
+        assert.deepStrictEqual(result, { kind: "unknown_current" });
+    });
 });
-
-

--- a/src/test/suite/integration/versionChecker.test.ts
+++ b/src/test/suite/integration/versionChecker.test.ts
@@ -44,7 +44,7 @@ suite("Integration: extensionVersionChecker", () => {
             return "Update Extensions"; // simulate user clicking
         };
         (vscode.commands.executeCommand as any) = async (cmd: string) => {
-            if (cmd === "workbench.view.extensions") openedExtensions = true;
+            if (cmd === "workbench.view.extensions") { openedExtensions = true; }
             return undefined;
         };
 

--- a/src/test/suite/unit/pinning.test.ts
+++ b/src/test/suite/unit/pinning.test.ts
@@ -1,0 +1,95 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+import {
+    findPinMismatches,
+    checkPinnedExtensionsForSync,
+    PinnedExtensions,
+} from "../../../utils/extensionVersionChecker";
+
+suite("Integration: Pinning Logic", () => {
+    const originalShowInfo = vscode.window.showInformationMessage;
+    const originalExecute = vscode.commands.executeCommand;
+    const originalGetExtension = vscode.extensions.getExtension;
+
+    let stubbedExtensions: Record<string, any> = {};
+
+    setup(() => {
+        stubbedExtensions = {
+            "project-accelerate.codex-editor-extension": {
+                packageJSON: { version: "0.24.0" }
+            },
+            "frontier-rnd.frontier-authentication": {
+                packageJSON: { version: "0.4.20" }
+            }
+        };
+
+        (vscode.extensions.getExtension as any) = (id: string) => stubbedExtensions[id];
+    });
+
+    teardown(() => {
+        (vscode.window.showInformationMessage as any) = originalShowInfo;
+        (vscode.commands.executeCommand as any) = originalExecute;
+        (vscode.extensions.getExtension as any) = originalGetExtension;
+    });
+
+    test("findPinMismatches detects mismatched versions", () => {
+        const pins: PinnedExtensions = {
+            "project-accelerate.codex-editor-extension": { version: "0.24.1", url: "http://example.com/vsix" },
+            "frontier-rnd.frontier-authentication": { version: "0.4.20", url: "http://example.com/vsix" }
+        };
+
+        const mismatches = findPinMismatches(pins);
+        assert.strictEqual(mismatches.length, 1);
+        assert.strictEqual(mismatches[0].extensionId, "project-accelerate.codex-editor-extension");
+        assert.strictEqual(mismatches[0].pinnedVersion, "0.24.1");
+        assert.strictEqual(mismatches[0].runningVersion, "0.24.0");
+    });
+
+    test("findPinMismatches returns empty when all match", () => {
+        const pins: PinnedExtensions = {
+            "project-accelerate.codex-editor-extension": { version: "0.24.0", url: "http://example.com/vsix" },
+            "frontier-rnd.frontier-authentication": { version: "0.4.20", url: "http://example.com/vsix" }
+        };
+
+        const mismatches = findPinMismatches(pins);
+        assert.strictEqual(mismatches.length, 0);
+    });
+
+    test("checkPinnedExtensionsForSync shows non-modal notification and blocks sync", async () => {
+        const pins: PinnedExtensions = {
+            "project-accelerate.codex-editor-extension": { version: "0.24.1", url: "http://example.com/vsix" }
+        };
+
+        let shownMessage: string | undefined;
+        (vscode.window.showInformationMessage as any) = async (msg: string, ...actions: string[]) => {
+            shownMessage = msg;
+            return undefined; // user dismisses
+        };
+
+        const result = await checkPinnedExtensionsForSync({ workspaceState: { get: () => 0 } } as any, true, pins);
+
+        assert.strictEqual(result.canSync, false);
+        assert.ok(shownMessage?.includes("Codex Editor"));
+        assert.ok(shownMessage?.includes("pinned to v0.24.1"));
+    });
+
+    test("checkPinnedExtensionsForSync reloads window when user clicks button", async () => {
+        const pins: PinnedExtensions = {
+            "project-accelerate.codex-editor-extension": { version: "0.24.1", url: "http://example.com/vsix" }
+        };
+
+        let reloaded = false;
+        (vscode.window.showInformationMessage as any) = async (msg: string, ...actions: string[]) => {
+            return "Reload Codex";
+        };
+        (vscode.commands.executeCommand as any) = async (cmd: string) => {
+            if (cmd === "workbench.action.reloadWindow") { reloaded = true; }
+            return undefined;
+        };
+
+        const result = await checkPinnedExtensionsForSync({ workspaceState: { get: () => 0 } } as any, true, pins);
+
+        assert.strictEqual(result.canSync, false);
+        assert.strictEqual(reloaded, true);
+    });
+});

--- a/src/test/suite/unit/pinning.test.ts
+++ b/src/test/suite/unit/pinning.test.ts
@@ -78,7 +78,7 @@ suite("Integration: Pinning Logic", () => {
         assert.strictEqual(compareVersions("0.24.1-pr5-abc1234", "0.24.2"), -1);
     });
 
-    test("checkPinnedExtensionsForSync shows non-modal notification and blocks sync", async () => {
+    test("checkPinnedExtensionsForSync shows info notification and blocks sync", async () => {
         const pins: PinnedExtensions = {
             "project-accelerate.codex-editor-extension": { version: "0.24.1", url: "http://example.com/vsix" }
         };
@@ -86,24 +86,25 @@ suite("Integration: Pinning Logic", () => {
         let shownMessage: string | undefined;
         (vscode.window.showInformationMessage as any) = async (msg: string, ...actions: string[]) => {
             shownMessage = msg;
-            return undefined; // user dismisses
+            return undefined;
         };
 
         const result = await checkPinnedExtensionsForSync({ workspaceState: { get: () => 0 } } as any, true, pins);
 
         assert.strictEqual(result.canSync, false);
+        assert.ok(shownMessage?.includes("Extension version pin detected"));
         assert.ok(shownMessage?.includes("Codex Editor"));
         assert.ok(shownMessage?.includes("pinned to v0.24.1"));
     });
 
-    test("checkPinnedExtensionsForSync reloads window when user clicks button", async () => {
+    test("checkPinnedExtensionsForSync does not reload — Conductor owns reload UX", async () => {
         const pins: PinnedExtensions = {
             "project-accelerate.codex-editor-extension": { version: "0.24.1", url: "http://example.com/vsix" }
         };
 
         let reloaded = false;
         (vscode.window.showInformationMessage as any) = async (msg: string, ...actions: string[]) => {
-            return "Reload Codex";
+            return undefined; // no reload button to click
         };
         (vscode.commands.executeCommand as any) = async (cmd: string) => {
             if (cmd === "workbench.action.reloadWindow") { reloaded = true; }
@@ -113,6 +114,6 @@ suite("Integration: Pinning Logic", () => {
         const result = await checkPinnedExtensionsForSync({ workspaceState: { get: () => 0 } } as any, true, pins);
 
         assert.strictEqual(result.canSync, false);
-        assert.strictEqual(reloaded, true);
+        assert.strictEqual(reloaded, false);
     });
 });

--- a/src/test/suite/unit/pinning.test.ts
+++ b/src/test/suite/unit/pinning.test.ts
@@ -116,4 +116,41 @@ suite("Integration: Pinning Logic", () => {
         assert.strictEqual(result.canSync, false);
         assert.strictEqual(reloaded, false);
     });
+
+    test("checkPinnedExtensionsForSync blocks sync if mismatching remote pins even if matching local", async () => {
+        const localPins: PinnedExtensions = {
+            "project-accelerate.codex-editor-extension": { version: "0.24.0", url: "http://example.com/vsix-v1" }
+        };
+        const remotePins: PinnedExtensions = {
+            "project-accelerate.codex-editor-extension": { version: "0.24.1", url: "http://example.com/vsix-v2" }
+        };
+
+        // Running version matches localPins (0.24.0) but NOT remotePins (0.24.1)
+        const result = await checkPinnedExtensionsForSync({ workspaceState: { get: () => 0 } } as any, true, remotePins);
+
+        assert.strictEqual(result.canSync, false);
+        assert.ok(result.pinnedIds.has("project-accelerate.codex-editor-extension"));
+    });
+
+    test("checkPinnedExtensionsForSync allows sync if matching remote pins even if local differs", async () => {
+        const localPins: PinnedExtensions = {
+            "project-accelerate.codex-editor-extension": { version: "0.24.0", url: "http://example.com/vsix-v1" }
+        };
+        const remotePins: PinnedExtensions = {
+            "project-accelerate.codex-editor-extension": { version: "0.24.1", url: "http://example.com/vsix-v2" }
+        };
+
+        // Running version matches remotePins (0.24.1)
+        stubbedExtensions["project-accelerate.codex-editor-extension"].packageJSON.version = "0.24.1";
+
+        try {
+            const result = await checkPinnedExtensionsForSync({ workspaceState: { get: () => 0 } } as any, true, remotePins);
+
+            assert.strictEqual(result.canSync, true);
+            assert.ok(result.pinnedIds.has("project-accelerate.codex-editor-extension"));
+        } finally {
+            // Restore version
+            stubbedExtensions["project-accelerate.codex-editor-extension"].packageJSON.version = "0.24.0";
+        }
+    });
 });

--- a/src/test/suite/unit/pinning.test.ts
+++ b/src/test/suite/unit/pinning.test.ts
@@ -1,6 +1,7 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
 import {
+    compareVersions,
     findPinMismatches,
     checkPinnedExtensionsForSync,
     PinnedExtensions,
@@ -53,6 +54,28 @@ suite("Integration: Pinning Logic", () => {
 
         const mismatches = findPinMismatches(pins);
         assert.strictEqual(mismatches.length, 0);
+    });
+
+    test("findPinMismatches requires exact string equality for pin versions", () => {
+        const pins: PinnedExtensions = {
+            "project-accelerate.codex-editor-extension": {
+                version: "0.24.0-pr123",
+                url: "http://example.com/vsix"
+            }
+        };
+
+        const mismatches = findPinMismatches(pins);
+        assert.strictEqual(mismatches.length, 1);
+        assert.strictEqual(mismatches[0].runningVersion, "0.24.0");
+        assert.strictEqual(mismatches[0].pinnedVersion, "0.24.0-pr123");
+    });
+
+    test("compareVersions ignores prerelease affixes for required version checks", () => {
+        assert.strictEqual(compareVersions("0.24.1", "0.24.1-pr123"), 0);
+        assert.strictEqual(compareVersions("0.24.1-pr122", "0.24.1-pr123"), 0);
+        assert.strictEqual(compareVersions("0.24.2-pr1", "0.24.1"), 1);
+        assert.strictEqual(compareVersions("0.24.1-pr5-abc1234", "0.24.1"), 0);
+        assert.strictEqual(compareVersions("0.24.1-pr5-abc1234", "0.24.2"), -1);
     });
 
     test("checkPinnedExtensionsForSync shows non-modal notification and blocks sync", async () => {

--- a/src/utils/extensionVersionChecker.ts
+++ b/src/utils/extensionVersionChecker.ts
@@ -414,6 +414,120 @@ export async function checkMetadataVersionsForSync(
     return false;
 }
 
+// ── Pinned extension sync gate ──────────────────────────────────────────────
+
+export interface PinnedExtensionEntry {
+    version: string;
+    url: string;
+}
+
+export type PinnedExtensions = Record<string, PinnedExtensionEntry>;
+
+/** Type guard to validate the PinnedExtensions structure. */
+export function isPinnedExtensions(obj: unknown): obj is PinnedExtensions {
+    if (!obj || typeof obj !== "object") {
+        return false;
+    }
+    for (const [key, value] of Object.entries(obj)) {
+        if (typeof key !== "string") {
+            return false;
+        }
+        const entry = value as Partial<PinnedExtensionEntry>;
+        if (typeof entry?.version !== "string" || typeof entry?.url !== "string") {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
+ * Reads pinnedExtensions from the local metadata.json.
+ * Returns the map if present, or undefined if absent/unreadable.
+ */
+async function readLocalPinnedExtensions(): Promise<PinnedExtensions | undefined> {
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    if (!workspaceFolder) {
+        return undefined;
+    }
+    try {
+        const metadataUri = vscode.Uri.joinPath(workspaceFolder.uri, "metadata.json");
+        const content = await vscode.workspace.fs.readFile(metadataUri);
+        const metadata = JSON.parse(new TextDecoder().decode(content));
+        const pins = metadata?.meta?.pinnedExtensions;
+        return isPinnedExtensions(pins) ? pins : undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+interface PinnedExtensionMismatch {
+    extensionId: string;
+    pinnedVersion: string;
+    runningVersion: string | null;
+}
+
+/** Strip publisher prefix and -extension suffix, title-case the rest. */
+function extensionDisplayName(extensionId: string): string {
+    const name = extensionId.includes(".")
+        ? extensionId.slice(extensionId.indexOf(".") + 1)
+        : extensionId;
+    return name
+        .replace(/-extension$/, "")
+        .split("-")
+        .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+        .join(" ");
+}
+
+/**
+ * Compares running extension versions against pinnedExtensions.
+ * Returns mismatches (pin exists but running version differs).
+ */
+export function findPinMismatches(pins: PinnedExtensions): PinnedExtensionMismatch[] {
+    const mismatches: PinnedExtensionMismatch[] = [];
+
+    for (const [extensionId, pin] of Object.entries(pins)) {
+        const runningVersion = getCurrentExtensionVersion(extensionId);
+
+        if (!runningVersion || compareVersions(runningVersion, pin.version) !== 0) {
+            mismatches.push({ extensionId, pinnedVersion: pin.version, runningVersion });
+        }
+    }
+
+    return mismatches;
+}
+
+function buildPinMismatchMessage(mismatches: PinnedExtensionMismatch[]): string {
+    const bullets = mismatches
+        .map((m) => `- ${extensionDisplayName(m.extensionId)} (pinned to v${m.pinnedVersion})`)
+        .join("\n");
+    return `To sync, reload Codex:\n${bullets}`;
+}
+
+/**
+ * Shows a non-modal notification for pin mismatches. Always returns false —
+ * either the user reloads (killing this session) or dismisses (blocking sync).
+ */
+async function showPinMismatchNotification(
+    mismatches: PinnedExtensionMismatch[]
+): Promise<false> {
+    const message = buildPinMismatchMessage(mismatches);
+
+    try {
+        const selection = await vscode.window.showInformationMessage(
+            message,
+            "Reload Codex"
+        );
+
+        if (selection === "Reload Codex") {
+            await vscode.commands.executeCommand("workbench.action.reloadWindow");
+        }
+    } catch (error) {
+        console.error("[PinVersionChecker] Error showing notification:", error);
+    }
+
+    return false;
+}
+
 export function registerVersionCheckCommands(context: vscode.ExtensionContext): void {
     // Generic check command that other extensions (e.g., Codex) can call
     vscode.commands.registerCommand(

--- a/src/utils/extensionVersionChecker.ts
+++ b/src/utils/extensionVersionChecker.ts
@@ -473,10 +473,11 @@ export async function handleOutdatedExtensionsForSync(
 
 export async function checkMetadataVersionsForSync(
     context: vscode.ExtensionContext,
-    isManualSync: boolean = false
+    isManualSync: boolean = false,
+    options?: { ignoreRemotePins?: boolean }
 ): Promise<boolean> {
     // Check pinned extensions first — pins override requiredExtensions
-    const pinResult = await checkPinnedExtensionsForSync(context, isManualSync);
+    const pinResult = await checkPinnedExtensionsForSync(context, isManualSync, undefined, options);
     if (!pinResult.canSync) {
         return false;
     }
@@ -544,7 +545,7 @@ export function isPinnedExtensions(obj: unknown): obj is PinnedExtensions {
  * Reads pinnedExtensions from the local metadata.json.
  * Returns the map if present, or undefined if absent/unreadable.
  */
-async function readLocalPinnedExtensions(): Promise<PinnedExtensions | undefined> {
+export async function readLocalPinnedExtensions(): Promise<PinnedExtensions | undefined> {
     const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
     if (!workspaceFolder) {
         return undefined;
@@ -626,7 +627,7 @@ async function showPinMismatchNotification(
 }
 
 /**
- * Checks if pinnedExtensions in metadata.json match the running versions.
+ * Checks if pinnedExtensions match the running versions.
  * If mismatched, shows a blocking modal prompting the user to reload.
  * Returns true if sync can proceed, false if blocked.
  *
@@ -636,23 +637,62 @@ async function showPinMismatchNotification(
 export async function checkPinnedExtensionsForSync(
     context: vscode.ExtensionContext,
     isManualSync: boolean,
-    pins?: PinnedExtensions
+    remotePins?: PinnedExtensions,
+    options?: { ignoreRemotePins?: boolean }
 ): Promise<{ canSync: boolean; pinnedIds: Set<string> }> {
-    const resolvedPins = pins ?? (await readLocalPinnedExtensions());
-    if (!resolvedPins || Object.keys(resolvedPins).length === 0) {
+    // 1. Check Admin Intent (Absolute Precedence)
+    // If the admin explicitly set an intent (e.g. they just applied a pin change),
+    // we bypass the remote check to allow the push.
+    const adminIntent = context.workspaceState.get<PinnedExtensions>("adminPinnedExtensions");
+    if (adminIntent && Object.keys(adminIntent).length > 0) {
+        debug("[PinVersionChecker] Admin intent active. Bypassing version checks for push.");
+        return { canSync: true, pinnedIds: new Set(Object.keys(adminIntent)) };
+    }
+
+    // 2. Check Remote Pins (Authoritative for Users)
+    if (!options?.ignoreRemotePins && remotePins && Object.keys(remotePins).length > 0) {
+        const mismatches = findPinMismatches(remotePins);
+        const pinnedIds = new Set(Object.keys(remotePins));
+
+        if (mismatches.length === 0) {
+            return { canSync: true, pinnedIds };
+        }
+
+        debug(
+            `[PinVersionChecker] Remote pin mismatch: ${mismatches
+                .map(
+                    (m) =>
+                        `${m.extensionId} running=${m.runningVersion} pinned=${m.pinnedVersion}`
+                )
+                .join(", ")}`
+        );
+
+        if (shouldShowVersionModal(context, isManualSync)) {
+            const canSync = await showPinMismatchNotification(mismatches);
+            return { canSync, pinnedIds };
+        }
+        return { canSync: false, pinnedIds };
+    }
+
+    // 3. Fall back to local pins from metadata.json
+    const localPins = await readLocalPinnedExtensions();
+    if (!localPins || Object.keys(localPins).length === 0) {
         return { canSync: true, pinnedIds: new Set() };
     }
 
-    const pinnedIds = new Set(Object.keys(resolvedPins));
-    const mismatches = findPinMismatches(resolvedPins);
+    const pinnedIds = new Set(Object.keys(localPins));
+    const mismatches = findPinMismatches(localPins);
 
     if (mismatches.length === 0) {
         return { canSync: true, pinnedIds };
     }
 
     debug(
-        `[PinVersionChecker] Pin mismatch: ${mismatches
-            .map((m) => `${m.extensionId} running=${m.runningVersion} pinned=${m.pinnedVersion}`)
+        `[PinVersionChecker] Local pin mismatch: ${mismatches
+            .map(
+                (m) =>
+                    `${m.extensionId} running=${m.runningVersion} pinned=${m.pinnedVersion}`
+            )
             .join(", ")}`
     );
 
@@ -662,7 +702,9 @@ export async function checkPinnedExtensionsForSync(
         return { canSync, pinnedIds };
     }
 
-    debug("[PinVersionChecker] Auto-sync blocked due to pin mismatch (in cooldown period)");
+    debug(
+        "[PinVersionChecker] Auto-sync blocked due to pin mismatch (in cooldown period)"
+    );
     return { canSync: false, pinnedIds };
 }
 

--- a/src/utils/extensionVersionChecker.ts
+++ b/src/utils/extensionVersionChecker.ts
@@ -8,16 +8,18 @@ import * as vscode from "vscode";
  * conflicts and the issues that were causing metadata.json to be deleted.
  */
 
-// Lightweight version comparator to avoid external semver dependency
+// Compare only the numeric x.y.z core. Affixes like -pr123 or -pr123-shorthash are ignored.
 export function compareVersions(a: string, b: string): number {
-    const normalize = (v: string) => v.trim().replace(/^v/i, "");
-    const parse = (v: string) => normalize(v).split(".").map((x) => parseInt(x, 10));
-    const pa = parse(a);
-    const pb = parse(b);
-    const len = Math.max(pa.length, pb.length);
-    for (let i = 0; i < len; i++) {
-        const ai = pa[i] ?? 0;
-        const bi = pb[i] ?? 0;
+    const pa = extractCoreVersionParts(a);
+    const pb = extractCoreVersionParts(b);
+
+    if (!pa || !pb) {
+        throw new Error(`Invalid version core: a=${a}, b=${b}`);
+    }
+
+    for (let i = 0; i < 3; i++) {
+        const ai = pa[i];
+        const bi = pb[i];
         if (ai > bi) { return 1; }
         if (ai < bi) { return -1; }
     }
@@ -46,6 +48,60 @@ const VERSION_MODAL_COOLDOWN_MS = 2 * 60 * 60 * 1000; // 2 hours
 function getCurrentExtensionVersion(extensionId: string): string | null {
     const extension = vscode.extensions.getExtension(extensionId);
     return (extension?.packageJSON as { version: string } | undefined)?.version || null;
+}
+
+function extractCoreVersionParts(version: string): [number, number, number] | null {
+    const match = version.trim().match(/^v?(\d+)\.(\d+)\.(\d+)/i);
+    if (!match) {
+        return null;
+    }
+
+    return [
+        parseInt(match[1], 10),
+        parseInt(match[2], 10),
+        parseInt(match[3], 10),
+    ];
+}
+
+export type RequiredVersionCheckResult =
+    | { kind: "ok"; comparison: -1 | 0 | 1 }
+    | { kind: "invalid_required" }
+    | { kind: "unknown_current" };
+
+export function checkRequiredVersion(
+    currentVersion: string | null,
+    requiredVersion: string,
+    extensionName: string
+): RequiredVersionCheckResult {
+    const requiredCore = extractCoreVersionParts(requiredVersion);
+    if (!requiredCore) {
+        console.warn(
+            `[MetadataVersionChecker] Invalid required version for ${extensionName}: ${requiredVersion}. Expected x.y.z. Allowing sync.`
+        );
+        return { kind: "invalid_required" };
+    }
+
+    if (!currentVersion) {
+        console.error(
+            `[MetadataVersionChecker] Missing installed version for ${extensionName} while required version ${requiredVersion} is set. Blocking sync.`
+        );
+        return { kind: "unknown_current" };
+    }
+
+    const currentCore = extractCoreVersionParts(currentVersion);
+    if (!currentCore) {
+        console.error(
+            `[MetadataVersionChecker] Unparseable installed version for ${extensionName}: ${currentVersion}. Blocking sync.`
+        );
+        return { kind: "unknown_current" };
+    }
+
+    for (let i = 0; i < 3; i++) {
+        if (currentCore[i] > requiredCore[i]) { return { kind: "ok", comparison: 1 }; }
+        if (currentCore[i] < requiredCore[i]) { return { kind: "ok", comparison: -1 }; }
+    }
+
+    return { kind: "ok", comparison: 0 };
 }
 
 export function getInstalledExtensionVersions(): {
@@ -193,7 +249,21 @@ export async function checkAndUpdateMetadataVersions(): Promise<MetadataVersionC
         }
 
         if (metadataCodexVersion) {
-            if (compareVersions(codexEditorVersion, metadataCodexVersion) < 0) {
+            const codexCheck = checkRequiredVersion(
+                codexEditorVersion,
+                metadataCodexVersion,
+                "Codex Editor"
+            );
+            if (codexCheck.kind === "unknown_current") {
+                return {
+                    canSync: false,
+                    metadataUpdated: false,
+                    reason: `Could not determine installed version for Codex Editor`,
+                    needsUserAction: true,
+                };
+            }
+
+            if (codexCheck.kind === "ok" && codexCheck.comparison < 0) {
                 console.warn(
                     `[MetadataVersionChecker] ⚠️  Codex Editor outdated: ${codexEditorVersion} < ${metadataCodexVersion}`
                 );
@@ -205,7 +275,7 @@ export async function checkAndUpdateMetadataVersions(): Promise<MetadataVersionC
                     downloadUrl: "",
                     displayName: "Codex Editor",
                 });
-            } else if (compareVersions(codexEditorVersion, metadataCodexVersion) > 0) {
+            } else if (codexCheck.kind === "ok" && codexCheck.comparison > 0) {
                 debug(
                     `[MetadataVersionChecker] 🚀 Updating Codex Editor version: ${metadataCodexVersion} → ${codexEditorVersion}`
                 );
@@ -215,7 +285,21 @@ export async function checkAndUpdateMetadataVersions(): Promise<MetadataVersionC
         }
 
         if (metadataFrontierVersion) {
-            if (compareVersions(frontierAuthVersion, metadataFrontierVersion) < 0) {
+            const frontierCheck = checkRequiredVersion(
+                frontierAuthVersion,
+                metadataFrontierVersion,
+                "Frontier Authentication"
+            );
+            if (frontierCheck.kind === "unknown_current") {
+                return {
+                    canSync: false,
+                    metadataUpdated: false,
+                    reason: `Could not determine installed version for Frontier Authentication`,
+                    needsUserAction: true,
+                };
+            }
+
+            if (frontierCheck.kind === "ok" && frontierCheck.comparison < 0) {
                 console.warn(
                     `[MetadataVersionChecker] ⚠️  Frontier Authentication outdated: ${frontierAuthVersion} < ${metadataFrontierVersion}`
                 );
@@ -227,7 +311,7 @@ export async function checkAndUpdateMetadataVersions(): Promise<MetadataVersionC
                     downloadUrl: "",
                     displayName: "Frontier Authentication",
                 });
-            } else if (compareVersions(frontierAuthVersion, metadataFrontierVersion) > 0) {
+            } else if (frontierCheck.kind === "ok" && frontierCheck.comparison > 0) {
                 debug(
                     `[MetadataVersionChecker] 🚀 Updating Frontier Authentication version: ${metadataFrontierVersion} → ${frontierAuthVersion}`
                 );
@@ -504,7 +588,7 @@ export function findPinMismatches(pins: PinnedExtensions): PinnedExtensionMismat
     for (const [extensionId, pin] of Object.entries(pins)) {
         const runningVersion = getCurrentExtensionVersion(extensionId);
 
-        if (!runningVersion || compareVersions(runningVersion, pin.version) !== 0) {
+        if (!runningVersion || runningVersion !== pin.version) {
             mismatches.push({ extensionId, pinnedVersion: pin.version, runningVersion });
         }
     }
@@ -611,7 +695,6 @@ export function registerVersionCheckCommands(context: vscode.ExtensionContext): 
 
                 // Mimic the remote metadata fetch/check
                 const { getInstalledExtensionVersions } = await import("./extensionVersionChecker");
-                const { compareVersions } = await import("./extensionVersionChecker");
 
                 // Fetch remote refs and read remote metadata.json (best effort)
                 try {
@@ -638,8 +721,32 @@ export function registerVersionCheckCommands(context: vscode.ExtensionContext): 
                                 const required = remoteMetadata.meta?.requiredExtensions;
                                 if (required) {
                                     const { codexEditorVersion, frontierAuthVersion } = getInstalledExtensionVersions();
-                                    if (required.codexEditor && codexEditorVersion && compareVersions(codexEditorVersion, required.codexEditor) < 0) { mismatch = true; }
-                                    if (required.frontierAuthentication && frontierAuthVersion && compareVersions(frontierAuthVersion, required.frontierAuthentication) < 0) { mismatch = true; }
+                                    if (required.codexEditor) {
+                                        const codexCheck = checkRequiredVersion(
+                                            codexEditorVersion,
+                                            required.codexEditor,
+                                            "Codex Editor"
+                                        );
+                                        if (
+                                            codexCheck.kind === "unknown_current" ||
+                                            (codexCheck.kind === "ok" && codexCheck.comparison < 0)
+                                        ) {
+                                            mismatch = true;
+                                        }
+                                    }
+                                    if (required.frontierAuthentication) {
+                                        const frontierCheck = checkRequiredVersion(
+                                            frontierAuthVersion,
+                                            required.frontierAuthentication,
+                                            "Frontier Authentication"
+                                        );
+                                        if (
+                                            frontierCheck.kind === "unknown_current" ||
+                                            (frontierCheck.kind === "ok" && frontierCheck.comparison < 0)
+                                        ) {
+                                            mismatch = true;
+                                        }
+                                    }
                                 }
                             } catch {}
                         }

--- a/src/utils/extensionVersionChecker.ts
+++ b/src/utils/extensionVersionChecker.ts
@@ -476,8 +476,29 @@ export async function checkMetadataVersionsForSync(
     isManualSync: boolean = false,
     options?: { ignoreRemotePins?: boolean }
 ): Promise<boolean> {
-    // Check pinned extensions first — pins override requiredExtensions
-    const pinResult = await checkPinnedExtensionsForSync(context, isManualSync, undefined, options);
+    // Use Conductor's effective pin resolution (reads IStorageService directly —
+    // no dependency on frontier's workspaceState or stale disk metadata)
+    const effectivePins: PinnedExtensions | undefined =
+        await vscode.commands.executeCommand("codex.conductor.getEffectivePinnedExtensions");
+    const pinResult = (() => {
+        if (!effectivePins || Object.keys(effectivePins).length === 0) {
+            return { canSync: true, pinnedIds: new Set<string>() };
+        }
+        const pinnedIds = new Set(Object.keys(effectivePins));
+        const mismatches = findPinMismatches(effectivePins);
+        if (mismatches.length === 0) {
+            return { canSync: true, pinnedIds };
+        }
+        debug(
+            `[PinVersionChecker] Conductor pin mismatch: ${mismatches
+                .map((m) => `${m.extensionId} running=${m.runningVersion} pinned=${m.pinnedVersion}`)
+                .join(", ")}`
+        );
+        if (shouldShowVersionModal(context, isManualSync)) {
+            showPinMismatchNotification(mismatches);
+        }
+        return { canSync: false, pinnedIds };
+    })();
     if (!pinResult.canSync) {
         return false;
     }
@@ -624,6 +645,39 @@ async function showPinMismatchNotification(
     }
 
     return false;
+}
+
+/**
+ * Post-fetch pin check: after writing fresh remote pins to workspaceState,
+ * asks the Conductor for the effective pins (which now include the just-written
+ * remote pins) and validates them against running extension versions.
+ *
+ * This catches newly discovered remote pins that weren't visible to the
+ * pre-fetch check in checkMetadataVersionsForSync.
+ */
+export async function checkEffectivePinsAfterFetch(
+    context: vscode.ExtensionContext,
+    isManualSync: boolean
+): Promise<{ canSync: boolean; pinnedIds: Set<string> }> {
+    const effectivePins: PinnedExtensions | undefined =
+        await vscode.commands.executeCommand("codex.conductor.getEffectivePinnedExtensions");
+    if (!effectivePins || Object.keys(effectivePins).length === 0) {
+        return { canSync: true, pinnedIds: new Set() };
+    }
+    const pinnedIds = new Set(Object.keys(effectivePins));
+    const mismatches = findPinMismatches(effectivePins);
+    if (mismatches.length === 0) {
+        return { canSync: true, pinnedIds };
+    }
+    debug(
+        `[PinVersionChecker] Post-fetch conductor pin mismatch: ${mismatches
+            .map((m) => `${m.extensionId} running=${m.runningVersion} pinned=${m.pinnedVersion}`)
+            .join(", ")}`
+    );
+    if (shouldShowVersionModal(context, isManualSync)) {
+        showPinMismatchNotification(mismatches);
+    }
+    return { canSync: false, pinnedIds };
 }
 
 /**

--- a/src/utils/extensionVersionChecker.ts
+++ b/src/utils/extensionVersionChecker.ts
@@ -600,12 +600,16 @@ function buildPinMismatchMessage(mismatches: PinnedExtensionMismatch[]): string 
     const bullets = mismatches
         .map((m) => `- ${extensionDisplayName(m.extensionId)} (pinned to v${m.pinnedVersion})`)
         .join("\n");
-    return `To sync, reload Codex:\n${bullets}`;
+    return `Extension version pin detected — sync paused.\n${bullets}`;
 }
 
 /**
- * Shows a non-modal notification for pin mismatches. Always returns false —
- * either the user reloads (killing this session) or dismisses (blocking sync).
+ * Shows a non-modal info notification for pin mismatches. Always returns
+ * false — sync stays blocked. No "Reload Codex" button: the Conductor
+ * (workbench contribution) owns all reload UX via authoritative reload,
+ * which guarantees the window lands in the correct profile. A plain
+ * `workbench.action.reloadWindow` would bypass that and risk a profile
+ * mismatch loop.
  */
 async function showPinMismatchNotification(
     mismatches: PinnedExtensionMismatch[]
@@ -613,14 +617,7 @@ async function showPinMismatchNotification(
     const message = buildPinMismatchMessage(mismatches);
 
     try {
-        const selection = await vscode.window.showInformationMessage(
-            message,
-            "Reload Codex"
-        );
-
-        if (selection === "Reload Codex") {
-            await vscode.commands.executeCommand("workbench.action.reloadWindow");
-        }
+        vscode.window.showInformationMessage(message);
     } catch (error) {
         console.error("[PinVersionChecker] Error showing notification:", error);
     }

--- a/src/utils/extensionVersionChecker.ts
+++ b/src/utils/extensionVersionChecker.ts
@@ -18,8 +18,8 @@ export function compareVersions(a: string, b: string): number {
     for (let i = 0; i < len; i++) {
         const ai = pa[i] ?? 0;
         const bi = pb[i] ?? 0;
-        if (ai > bi) return 1;
-        if (ai < bi) return -1;
+        if (ai > bi) { return 1; }
+        if (ai < bi) { return -1; }
     }
     return 0;
 }
@@ -45,7 +45,7 @@ const VERSION_MODAL_COOLDOWN_MS = 2 * 60 * 60 * 1000; // 2 hours
 
 function getCurrentExtensionVersion(extensionId: string): string | null {
     const extension = vscode.extensions.getExtension(extensionId);
-    return (extension as any)?.packageJSON?.version || null;
+    return (extension?.packageJSON as { version: string } | undefined)?.version || null;
 }
 
 export function getInstalledExtensionVersions(): {
@@ -151,8 +151,8 @@ export async function checkAndUpdateMetadataVersions(): Promise<MetadataVersionC
 
         if (!codexEditorVersion || !frontierAuthVersion) {
             const missingExtensions: string[] = [];
-            if (!codexEditorVersion) missingExtensions.push("Codex Editor");
-            if (!frontierAuthVersion) missingExtensions.push("Frontier Authentication");
+            if (!codexEditorVersion) { missingExtensions.push("Codex Editor"); }
+            if (!frontierAuthVersion) { missingExtensions.push("Frontier Authentication"); }
 
             console.error(
                 `[MetadataVersionChecker] ❌ Missing required extensions: ${missingExtensions.join(", ")}`
@@ -188,8 +188,8 @@ export async function checkAndUpdateMetadataVersions(): Promise<MetadataVersionC
         if (!metadataCodexVersion || !metadataFrontierVersion) {
             debug("[MetadataVersionChecker] ➕ Adding missing extension version requirements to metadata");
             needsUpdate = true;
-            if (!metadataCodexVersion) versionsToUpdate.codexEditor = codexEditorVersion;
-            if (!metadataFrontierVersion) versionsToUpdate.frontierAuthentication = frontierAuthVersion;
+            if (!metadataCodexVersion) { versionsToUpdate.codexEditor = codexEditorVersion; }
+            if (!metadataFrontierVersion) { versionsToUpdate.frontierAuthentication = frontierAuthVersion; }
         }
 
         if (metadataCodexVersion) {
@@ -319,12 +319,12 @@ export function buildOutdatedExtensionsMessage(outdatedExtensions: ExtensionVers
     const names = outdatedExtensions.map((e) => e.displayName);
 
     const formatNames = (arr: string[]): string => {
-        if (arr.length <= 1) return arr[0] || "";
-        if (arr.length === 2) return `${arr[0]} and ${arr[1]}`;
+        if (arr.length <= 1) { return arr[0] || ""; }
+        if (arr.length === 2) { return `${arr[0]} and ${arr[1]}`; }
         return `${arr.slice(0, -1).join(", ")}, and ${arr[arr.length - 1]}`;
     };
 
-    if (names.length === 0) return "To sync, update:"; // safety fallback
+    if (names.length === 0) { return "To sync, update:"; } // safety fallback
     const bullets = names.map((n) => `- ${n}`).join("\n");
     return `To sync, update:\n${bullets}`;
 }
@@ -436,7 +436,7 @@ export function registerVersionCheckCommands(context: vscode.ExtensionContext): 
         async (): Promise<boolean> => {
             try {
                 const workspacePath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-                if (!workspacePath) return true;
+                if (!workspacePath) { return true; }
 
                 // Mimic the remote metadata fetch/check
                 const { getInstalledExtensionVersions } = await import("./extensionVersionChecker");
@@ -467,8 +467,8 @@ export function registerVersionCheckCommands(context: vscode.ExtensionContext): 
                                 const required = remoteMetadata.meta?.requiredExtensions;
                                 if (required) {
                                     const { codexEditorVersion, frontierAuthVersion } = getInstalledExtensionVersions();
-                                    if (required.codexEditor && codexEditorVersion && compareVersions(codexEditorVersion, required.codexEditor) < 0) mismatch = true;
-                                    if (required.frontierAuthentication && frontierAuthVersion && compareVersions(frontierAuthVersion, required.frontierAuthentication) < 0) mismatch = true;
+                                    if (required.codexEditor && codexEditorVersion && compareVersions(codexEditorVersion, required.codexEditor) < 0) { mismatch = true; }
+                                    if (required.frontierAuthentication && frontierAuthVersion && compareVersions(frontierAuthVersion, required.frontierAuthentication) < 0) { mismatch = true; }
                                 }
                             } catch {}
                         }

--- a/src/utils/extensionVersionChecker.ts
+++ b/src/utils/extensionVersionChecker.ts
@@ -391,6 +391,12 @@ export async function checkMetadataVersionsForSync(
     context: vscode.ExtensionContext,
     isManualSync: boolean = false
 ): Promise<boolean> {
+    // Check pinned extensions first — pins override requiredExtensions
+    const pinResult = await checkPinnedExtensionsForSync(context, isManualSync);
+    if (!pinResult.canSync) {
+        return false;
+    }
+
     const result = await checkAndUpdateMetadataVersions();
 
     if (result.canSync) {
@@ -398,10 +404,20 @@ export async function checkMetadataVersionsForSync(
     }
 
     if (result.needsUserAction && result.outdatedExtensions) {
+        // Filter out extensions that are covered by a pin
+        const nonPinnedOutdated = result.outdatedExtensions.filter(
+            (ext) => !pinResult.pinnedIds.has(ext.extensionId)
+        );
+
+        if (nonPinnedOutdated.length === 0) {
+            // All outdated extensions are pinned — pins override, allow sync
+            return true;
+        }
+
         const shouldShow = shouldShowVersionModal(context, isManualSync);
 
         if (shouldShow) {
-            return await showMetadataVersionMismatchNotification(context, result.outdatedExtensions);
+            return await showMetadataVersionMismatchNotification(context, nonPinnedOutdated);
         } else {
             debug(
                 "[MetadataVersionChecker] Auto-sync blocked due to outdated extensions (in cooldown period)"
@@ -526,6 +542,47 @@ async function showPinMismatchNotification(
     }
 
     return false;
+}
+
+/**
+ * Checks if pinnedExtensions in metadata.json match the running versions.
+ * If mismatched, shows a blocking modal prompting the user to reload.
+ * Returns true if sync can proceed, false if blocked.
+ *
+ * Also returns the set of pinned extension IDs so callers can skip
+ * requiredExtensions checks for those extensions.
+ */
+export async function checkPinnedExtensionsForSync(
+    context: vscode.ExtensionContext,
+    isManualSync: boolean,
+    pins?: PinnedExtensions
+): Promise<{ canSync: boolean; pinnedIds: Set<string> }> {
+    const resolvedPins = pins ?? (await readLocalPinnedExtensions());
+    if (!resolvedPins || Object.keys(resolvedPins).length === 0) {
+        return { canSync: true, pinnedIds: new Set() };
+    }
+
+    const pinnedIds = new Set(Object.keys(resolvedPins));
+    const mismatches = findPinMismatches(resolvedPins);
+
+    if (mismatches.length === 0) {
+        return { canSync: true, pinnedIds };
+    }
+
+    debug(
+        `[PinVersionChecker] Pin mismatch: ${mismatches
+            .map((m) => `${m.extensionId} running=${m.runningVersion} pinned=${m.pinnedVersion}`)
+            .join(", ")}`
+    );
+
+    const shouldShow = shouldShowVersionModal(context, isManualSync);
+    if (shouldShow) {
+        const canSync = await showPinMismatchNotification(mismatches);
+        return { canSync, pinnedIds };
+    }
+
+    debug("[PinVersionChecker] Auto-sync blocked due to pin mismatch (in cooldown period)");
+    return { canSync: false, pinnedIds };
 }
 
 export function registerVersionCheckCommands(context: vscode.ExtensionContext): void {

--- a/src/utils/extensionVersionChecker.ts
+++ b/src/utils/extensionVersionChecker.ts
@@ -510,7 +510,12 @@ export async function checkMetadataVersionsForSync(
     }
 
     if (result.needsUserAction && result.outdatedExtensions) {
-        // Filter out extensions that are covered by a pin
+        // Filter out extensions that are covered by a pin.
+        // TODO: If the remote just removed pinnedExtensions AND bumped requiredExtensions
+        // in the same commit, the conductor may still return stale local pins here
+        // (it falls back to local metadata.json when remote pins are empty). This would
+        // incorrectly suppress the requiredExtensions check for one sync cycle. The merge
+        // updates local metadata.json, so the next sync self-corrects.
         const nonPinnedOutdated = result.outdatedExtensions.filter(
             (ext) => !pinResult.pinnedIds.has(ext.extensionId)
         );


### PR DESCRIPTION
Prevent sync when pinned extension versions don't match the running versions, and signal sync completion so the Codex Conductor can detect mid-session pin changes.

See architecture docs:
- [Extension Pinning Project](https://github.com/genesis-ai-dev/codex/blob/main/2026-03-project-extension-pinning.md)
- [Pin Enforcement Scenarios](https://github.com/genesis-ai-dev/codex/blob/main/2026-03-pin-enforcement-scenarios.md)

## Changes
- Signal `syncCompletedAt` timestamp to workspaceState after successful sync for Conductor observability
- Add `PinnedExtensions` types, type guard, and mismatch detection utilities
- Add `checkPinnedExtensionsForSync()` with 2-hour notification cooldown
- Integrate pin checks into `checkMetadataVersionsForSync()` — pins override `requiredExtensions`
- Add `handleRemotePinValidation()` in SCMManager to write remote pins to workspaceState and gate sync
- Skip `requiredExtensions` version checks for pinned extension IDs
- Style: consistent braces on single-line if statements

## Test plan (current stable Codex — no Conductor)
- [ ] Verify sync completes normally when no pins are present in metadata.json (regression — existing behavior unchanged)
- [ ] Verify `requiredExtensions` version checks still work as before (regression)
- [ ] Run `pnpm test` — new pinning.test.ts covers mismatch detection and notification behavior

## Test plan (Codex beta with Conductor)
- [ ] Pin a project via admin CLI and verify sync is blocked with "Reload Codex" notification when pinned version doesn't match running version
- [ ] Confirm "Reload Codex" triggers window reload and Conductor switches to pinned profile
- [ ] Verify pinned extensions bypass `requiredExtensions` ratchet checks
- [ ] Confirm notification cooldown: auto-sync suppresses repeat notifications within 2 hours
- [ ] Confirm `syncCompletedAt` is written to workspaceState after successful sync; Conductor re-evaluates pins
- [ ] Confirm `remotePinnedExtensions` is written to workspaceState during remote metadata check, even when sync aborts before merge
- [ ] Walk through Scenario 2 (sync receives new pin): Frontier writes remote pins, Conductor installs VSIX and switches profile
- [ ] Walk through Scenario 3 (pin removed): Frontier clears remotePinnedExtensions, Conductor switches back to Default profile