### PR TITLE
feat: implement extension version pin sync gate

### DIFF
--- a/src/scm/SCMManager.ts
+++ b/src/scm/SCMManager.ts
@@ -11,10 +11,11 @@ import { ResolvedFile } from "../extension";
 import { MediaFilesStrategy } from "../types/state";
 import { checkMetadataVersionsForSync } from "../utils/extensionVersionChecker";
 import {
-    compareVersions,
+    checkRequiredVersion,
     getInstalledExtensionVersions,
     handleOutdatedExtensionsForSync,
     ExtensionVersionInfo,
+    readLocalPinnedExtensions,
 } from "../utils/extensionVersionChecker";
 
 export class SCMManager {
@@ -112,6 +113,16 @@ export class SCMManager {
         this.context.subscriptions.push(
             vscode.commands.registerCommand(
                 "frontier.syncChanges",
+                (options?: { commitMessage?: string }) => this.syncChanges(options, true)
+            )
+        );
+
+        // Push pin update command (admin-only). The Conductor's admin intent
+        // (adminPinnedExtensions) ensures getPinMismatches() returns empty when
+        // the running version matches the admin's intended pin, so sync proceeds.
+        this.context.subscriptions.push(
+            vscode.commands.registerCommand(
+                "frontier.pushPinUpdate",
                 (options?: { commitMessage?: string }) => this.syncChanges(options, true)
             )
         );
@@ -415,6 +426,39 @@ export class SCMManager {
         });
     }
 
+    private async handleRemotePinValidation(
+        remotePins: Record<string, { version: string; url: string }> | undefined,
+        isManualSync: boolean
+    ): Promise<{ canSync: boolean; pinnedIds: Set<string> }> {
+        // Delegate to the Conductor (handles Admin Intent > Remote > Local priority).
+        // setRemotePins fires before aborting so the Conductor can start downloading.
+        try {
+            await vscode.commands.executeCommand("codex.conductor.setRemotePins", remotePins);
+
+            // Ask the Conductor for mismatches.
+            const mismatches = await vscode.commands.executeCommand<{
+                extensionId: string;
+                pinnedVersion: string;
+                runningVersion: string | null;
+            }[]>("codex.conductor.getPinMismatches");
+
+            if (mismatches && mismatches.length > 0) {
+                // Return canSync: false to block the fetch loop.
+                // checkMetadataVersionsForSync will handle showing the notification
+                // on the next iteration (or if we're in the pre-sync check).
+                return { canSync: false, pinnedIds: new Set() };
+            }
+
+            // Also get effective pinned IDs so we can bypass requiredExtensions checks
+            const effectivePins = await vscode.commands.executeCommand<Record<string, any>>(
+                "codex.conductor.getEffectivePinnedExtensions"
+            );
+            return { canSync: true, pinnedIds: new Set(Object.keys(effectivePins || {})) };
+        } catch {
+            return { canSync: true, pinnedIds: new Set() };
+        }
+    }
+
     async syncChanges(
         options?: { commitMessage?: string },
         isManualSync: boolean = false
@@ -526,8 +570,18 @@ export class SCMManager {
                                         codexEditor?: string;
                                         frontierAuthentication?: string;
                                     };
+                                    pinnedExtensions?: Record<string, { version: string; url: string }>;
                                 };
                             };
+
+                            // Write remote pins to workspaceState, then ask the Conductor
+                            // for effective pins (which now include the just-fetched remote pins).
+                            const remotePins = remoteMetadata.meta?.pinnedExtensions;
+                            const { canSync: canSyncPins, pinnedIds } =
+                                await this.handleRemotePinValidation(remotePins, isManualSync);
+                            if (!canSyncPins) {
+                                return { hasConflicts: false };
+                            }
 
                             const required = remoteMetadata.meta?.requiredExtensions;
                             if (required) {
@@ -535,14 +589,16 @@ export class SCMManager {
                                     getInstalledExtensionVersions();
                                 const outdated: ExtensionVersionInfo[] = [];
 
-                                if (
-                                    required.codexEditor &&
-                                    codexEditorVersion &&
-                                    compareVersions(codexEditorVersion, required.codexEditor) < 0
-                                ) {
+                                const isOutdatedOrUnknown = (check: ReturnType<typeof checkRequiredVersion>): boolean =>
+                                    check.kind === "unknown_current" || (check.kind === "ok" && check.comparison < 0);
+
+                                const codexCheck = checkRequiredVersion(codexEditorVersion, required.codexEditor ?? "", "Codex Editor");
+                                const frontierCheck = checkRequiredVersion(frontierAuthVersion, required.frontierAuthentication ?? "", "Frontier Authentication");
+
+                                if (required.codexEditor && !pinnedIds.has("project-accelerate.codex-editor-extension") && isOutdatedOrUnknown(codexCheck)) {
                                     outdated.push({
                                         extensionId: "project-accelerate.codex-editor-extension",
-                                        currentVersion: codexEditorVersion,
+                                        currentVersion: codexEditorVersion ?? "unknown",
                                         latestVersion: required.codexEditor,
                                         isOutdated: true,
                                         downloadUrl: "",
@@ -550,17 +606,10 @@ export class SCMManager {
                                     });
                                 }
 
-                                if (
-                                    required.frontierAuthentication &&
-                                    frontierAuthVersion &&
-                                    compareVersions(
-                                        frontierAuthVersion,
-                                        required.frontierAuthentication
-                                    ) < 0
-                                ) {
+                                if (required.frontierAuthentication && !pinnedIds.has("frontier-rnd.frontier-authentication") && isOutdatedOrUnknown(frontierCheck)) {
                                     outdated.push({
                                         extensionId: "frontier-rnd.frontier-authentication",
-                                        currentVersion: frontierAuthVersion,
+                                        currentVersion: frontierAuthVersion ?? "unknown",
                                         latestVersion: required.frontierAuthentication,
                                         isOutdated: true,
                                         downloadUrl: "",
@@ -666,6 +715,22 @@ export class SCMManager {
                     status: "completed",
                     message: "Synchronization complete",
                 });
+
+                // After a successful sync (fetch -> merge -> push), the local and remote
+                // states are converged. We refresh remotePinnedExtensions storage to match
+                // what we just pushed, ensuring the Conductor sees the latest pins on next reload.
+                try {
+                    const convergedPins = await readLocalPinnedExtensions();
+                    await vscode.commands.executeCommand("codex.conductor.setRemotePins", convergedPins);
+                } catch (e) {
+                    console.error("[SCMManager] Failed to refresh remote pins after sync:", e);
+                }
+
+                // Clear the admin intent (override) since the change is now authoritative on the remote.
+                try {
+                    await vscode.commands.executeCommand("codex.conductor.clearAdminPinIntent");
+                    await vscode.commands.executeCommand("codex.conductor.setSyncCompletedAt", Date.now());
+                } catch {}
             }
         }
     }

--- a/src/test/suite/integration/versionChecker.test.ts
+++ b/src/test/suite/integration/versionChecker.test.ts
@@ -6,6 +6,7 @@ import {
     handleOutdatedExtensionsForSync,
     buildOutdatedExtensionsMessage,
     ExtensionVersionInfo,
+    checkRequiredVersion,
 } from "../../../utils/extensionVersionChecker";
 
 suite("Integration: extensionVersionChecker", () => {
@@ -44,7 +45,7 @@ suite("Integration: extensionVersionChecker", () => {
             return "Update Extensions"; // simulate user clicking
         };
         (vscode.commands.executeCommand as any) = async (cmd: string) => {
-            if (cmd === "workbench.view.extensions") openedExtensions = true;
+            if (cmd === "workbench.view.extensions") { openedExtensions = true; }
             return undefined;
         };
 
@@ -84,6 +85,33 @@ suite("Integration: extensionVersionChecker", () => {
         await handleOutdatedExtensionsForSync({} as any, outdated, true);
         const expected = buildOutdatedExtensionsMessage(outdated);
         assert.strictEqual(shownMessage, expected);
+    });
+
+    test("malformed required version fails open without showing a toast", () => {
+        let shownMessage: string | undefined;
+        (vscode.window.showWarningMessage as any) = async (msg: string) => {
+            shownMessage = msg;
+            return undefined;
+        };
+
+        const result = checkRequiredVersion(
+            "0.24.1-pr123",
+            "not-a-version",
+            "Codex Editor"
+        );
+
+        assert.deepStrictEqual(result, { kind: "invalid_required" });
+        assert.strictEqual(shownMessage, undefined);
+    });
+
+    test("valid required version with missing installed version fails closed", () => {
+        const result = checkRequiredVersion(
+            null,
+            "0.24.1",
+            "Codex Editor"
+        );
+
+        assert.deepStrictEqual(result, { kind: "unknown_current" });
     });
 });
 

--- a/src/test/suite/unit/pinning.test.ts
+++ b/src/test/suite/unit/pinning.test.ts
@@ -1,0 +1,14 @@
+import * as assert from "assert";
+import {
+    compareVersions,
+} from "../../../utils/extensionVersionChecker";
+
+suite("Unit: Version Comparison", () => {
+    test("compareVersions ignores prerelease affixes for required version checks", () => {
+        assert.strictEqual(compareVersions("0.24.1", "0.24.1-pr123"), 0);
+        assert.strictEqual(compareVersions("0.24.1-pr122", "0.24.1-pr123"), 0);
+        assert.strictEqual(compareVersions("0.24.2-pr1", "0.24.1"), 1);
+        assert.strictEqual(compareVersions("0.24.1-pr5-abc1234", "0.24.1"), 0);
+        assert.strictEqual(compareVersions("0.24.1-pr5-abc1234", "0.24.2"), -1);
+    });
+});

--- a/src/utils/extensionVersionChecker.ts
+++ b/src/utils/extensionVersionChecker.ts
@@ -29,6 +29,63 @@ export function compareVersions(a: string, b: string): number {
 /**
  * Parses out the x.y.z core of a version string.
  */
+/**
+ * Compare a running extension version against a required version from metadata.json's
+ * `requiredExtensions`. Both are reduced to their x.y.z numeric core — affixes like
+ * `-pr123` or `-pr123-shorthash` are stripped — so `0.24.1-pr123` == `0.24.1`.
+ *
+ * Returns a discriminated union:
+ *
+ *   "ok"               — both parsed; `comparison` is -1 / 0 / 1 (current vs required).
+ *                        -1 means outdated → block sync.
+ *
+ *   "invalid_required" — requiredVersion couldn't be parsed as x.y.z; fail-open
+ *                        (allow sync, log warning, no toast). Scenario 10.
+ *
+ *   "unknown_current"  — requiredVersion is valid but currentVersion is null or
+ *                        unparseable; fail-closed (block sync). Scenario 11.
+ */
+export type RequiredVersionCheckResult =
+    | { kind: "ok"; comparison: -1 | 0 | 1 }
+    | { kind: "invalid_required" }
+    | { kind: "unknown_current" };
+
+export function checkRequiredVersion(
+    currentVersion: string | null,
+    requiredVersion: string,
+    extensionName: string
+): RequiredVersionCheckResult {
+    const requiredCore = extractCoreVersionParts(requiredVersion);
+    if (!requiredCore) {
+        console.warn(
+            `[MetadataVersionChecker] Invalid required version for ${extensionName}: ${requiredVersion}. Expected x.y.z. Allowing sync.`
+        );
+        return { kind: "invalid_required" };
+    }
+
+    if (!currentVersion) {
+        console.error(
+            `[MetadataVersionChecker] Missing installed version for ${extensionName} while required version ${requiredVersion} is set. Blocking sync.`
+        );
+        return { kind: "unknown_current" };
+    }
+
+    const currentCore = extractCoreVersionParts(currentVersion);
+    if (!currentCore) {
+        console.error(
+            `[MetadataVersionChecker] Unparseable installed version for ${extensionName}: ${currentVersion}. Blocking sync.`
+        );
+        return { kind: "unknown_current" };
+    }
+
+    for (let i = 0; i < 3; i++) {
+        if (currentCore[i] > requiredCore[i]) { return { kind: "ok", comparison: 1 }; }
+        if (currentCore[i] < requiredCore[i]) { return { kind: "ok", comparison: -1 }; }
+    }
+
+    return { kind: "ok", comparison: 0 };
+}
+
 function extractCoreVersionParts(version: string): [number, number, number] | null {
     const match = version.trim().match(/^v?(\d+)\.(\d+)\.(\d+)/i);
     if (!match) {
@@ -211,7 +268,21 @@ export async function checkAndUpdateMetadataVersions(): Promise<MetadataVersionC
         }
 
         if (metadataCodexVersion) {
-            if (compareVersions(codexEditorVersion, metadataCodexVersion) < 0) {
+            const codexCheck = checkRequiredVersion(
+                codexEditorVersion,
+                metadataCodexVersion,
+                "Codex Editor"
+            );
+            if (codexCheck.kind === "unknown_current") {
+                return {
+                    canSync: false,
+                    metadataUpdated: false,
+                    reason: `Could not determine installed version for Codex Editor`,
+                    needsUserAction: true,
+                };
+            }
+
+            if (codexCheck.kind === "ok" && codexCheck.comparison < 0) {
                 console.warn(
                     `[MetadataVersionChecker] ⚠️  Codex Editor outdated: ${codexEditorVersion} < ${metadataCodexVersion}`
                 );
@@ -223,7 +294,7 @@ export async function checkAndUpdateMetadataVersions(): Promise<MetadataVersionC
                     downloadUrl: "",
                     displayName: "Codex Editor",
                 });
-            } else if (compareVersions(codexEditorVersion, metadataCodexVersion) > 0) {
+            } else if (codexCheck.kind === "ok" && codexCheck.comparison > 0) {
                 debug(
                     `[MetadataVersionChecker] 🚀 Updating Codex Editor version: ${metadataCodexVersion} → ${codexEditorVersion}`
                 );
@@ -233,7 +304,21 @@ export async function checkAndUpdateMetadataVersions(): Promise<MetadataVersionC
         }
 
         if (metadataFrontierVersion) {
-            if (compareVersions(frontierAuthVersion, metadataFrontierVersion) < 0) {
+            const frontierCheck = checkRequiredVersion(
+                frontierAuthVersion,
+                metadataFrontierVersion,
+                "Frontier Authentication"
+            );
+            if (frontierCheck.kind === "unknown_current") {
+                return {
+                    canSync: false,
+                    metadataUpdated: false,
+                    reason: `Could not determine installed version for Frontier Authentication`,
+                    needsUserAction: true,
+                };
+            }
+
+            if (frontierCheck.kind === "ok" && frontierCheck.comparison < 0) {
                 console.warn(
                     `[MetadataVersionChecker] ⚠️  Frontier Authentication outdated: ${frontierAuthVersion} < ${metadataFrontierVersion}`
                 );
@@ -245,7 +330,7 @@ export async function checkAndUpdateMetadataVersions(): Promise<MetadataVersionC
                     downloadUrl: "",
                     displayName: "Frontier Authentication",
                 });
-            } else if (compareVersions(frontierAuthVersion, metadataFrontierVersion) > 0) {
+            } else if (frontierCheck.kind === "ok" && frontierCheck.comparison > 0) {
                 debug(
                     `[MetadataVersionChecker] 🚀 Updating Frontier Authentication version: ${metadataFrontierVersion} → ${frontierAuthVersion}`
                 );

--- a/src/utils/extensionVersionChecker.ts
+++ b/src/utils/extensionVersionChecker.ts
@@ -26,9 +26,43 @@ export function compareVersions(a: string, b: string): number {
     return 0;
 }
 
-/**
- * Parses out the x.y.z core of a version string.
- */
+const DEBUG_MODE = false;
+const debug = (message: string) => {
+    if (DEBUG_MODE) {
+        console.log(`[ExtensionVersionChecker] ${message}`);
+    }
+};
+
+export interface ExtensionVersionInfo {
+    extensionId: string;
+    currentVersion: string;
+    latestVersion: string;
+    isOutdated: boolean;
+    downloadUrl: string;
+    displayName: string;
+}
+
+const VERSION_MODAL_COOLDOWN_KEY = "codex-editor.versionModalLastShown";
+const VERSION_MODAL_COOLDOWN_MS = 2 * 60 * 60 * 1000; // 2 hours
+
+function getCurrentExtensionVersion(extensionId: string): string | null {
+    const extension = vscode.extensions.getExtension(extensionId);
+    return (extension?.packageJSON as { version: string } | undefined)?.version || null;
+}
+
+function extractCoreVersionParts(version: string): [number, number, number] | null {
+    const match = version.trim().match(/^v?(\d+)\.(\d+)\.(\d+)/i);
+    if (!match) {
+        return null;
+    }
+
+    return [
+        parseInt(match[1], 10),
+        parseInt(match[2], 10),
+        parseInt(match[3], 10),
+    ];
+}
+
 /**
  * Compare a running extension version against a required version from metadata.json's
  * `requiredExtensions`. Both are reduced to their x.y.z numeric core — affixes like
@@ -84,43 +118,6 @@ export function checkRequiredVersion(
     }
 
     return { kind: "ok", comparison: 0 };
-}
-
-function extractCoreVersionParts(version: string): [number, number, number] | null {
-    const match = version.trim().match(/^v?(\d+)\.(\d+)\.(\d+)/i);
-    if (!match) {
-        return null;
-    }
-
-    return [
-        parseInt(match[1], 10),
-        parseInt(match[2], 10),
-        parseInt(match[3], 10),
-    ];
-}
-
-const DEBUG_MODE = false;
-const debug = (message: string) => {
-    if (DEBUG_MODE) {
-        console.log(`[ExtensionVersionChecker] ${message}`);
-    }
-};
-
-export interface ExtensionVersionInfo {
-    extensionId: string;
-    currentVersion: string;
-    latestVersion: string;
-    isOutdated: boolean;
-    downloadUrl: string;
-    displayName: string;
-}
-
-const VERSION_MODAL_COOLDOWN_KEY = "codex-editor.versionModalLastShown";
-const VERSION_MODAL_COOLDOWN_MS = 2 * 60 * 60 * 1000; // 2 hours
-
-function getCurrentExtensionVersion(extensionId: string): string | null {
-    const extension = vscode.extensions.getExtension(extensionId);
-    return (extension as any)?.packageJSON?.version || null;
 }
 
 export function getInstalledExtensionVersions(): {
@@ -432,66 +429,7 @@ export function buildOutdatedExtensionsMessage(outdatedExtensions: ExtensionVers
     return `To sync, update:\n${bullets}`;
 }
 
-// ── Pinned extension sync gate ──────────────────────────────────────────────
-
-export interface PinnedExtensionEntry {
-    version: string;
-    url: string;
-}
-
-export type PinnedExtensions = Record<string, PinnedExtensionEntry>;
-
-/** Type guard to validate the PinnedExtensions structure. */
-export function isPinnedExtensions(obj: unknown): obj is PinnedExtensions {
-    if (!obj || typeof obj !== "object") {
-        return false;
-    }
-    for (const [key, value] of Object.entries(obj)) {
-        if (typeof key !== "string") {
-            return false;
-        }
-        const entry = value as Partial<PinnedExtensionEntry>;
-        if (typeof entry?.version !== "string" || typeof entry?.url !== "string") {
-            return false;
-        }
-    }
-    return true;
-}
-
-/**
- * Reads pinnedExtensions from the local metadata.json.
- * Returns the map if present, or undefined if absent/unreadable.
- */
-export async function readLocalPinnedExtensions(): Promise<PinnedExtensions | undefined> {
-    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-    if (!workspaceFolder) {
-        return undefined;
-    }
-    try {
-        const metadataUri = vscode.Uri.joinPath(workspaceFolder.uri, "metadata.json");
-        const content = await vscode.workspace.fs.readFile(metadataUri);
-        const metadata = JSON.parse(new TextDecoder().decode(content));
-        const pins = metadata?.meta?.pinnedExtensions;
-        return isPinnedExtensions(pins) ? pins : undefined;
-    } catch {
-        return undefined;
-    }
-}
-
-/** Strip publisher prefix and -extension suffix, title-case the rest. */
-function extensionDisplayName(extensionId: string): string {
-    const name = extensionId.includes(".")
-        ? extensionId.slice(extensionId.indexOf(".") + 1)
-        : extensionId;
-    return name
-        .replace(/-extension$/, "")
-        .split("-")
-        .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-        .join(" ");
-}
-
-export function registerVersionCheckCommands(context: vscode.ExtensionContext): void {
-
+async function showMetadataVersionMismatchNotification(
     context: vscode.ExtensionContext,
     outdatedExtensions: ExtensionVersionInfo[]
 ): Promise<boolean> {
@@ -615,6 +553,64 @@ export async function checkMetadataVersionsForSync(
 
     console.warn("[MetadataVersionChecker] Sync not allowed:", result.reason);
     return false;
+}
+
+// ── Pinned extension sync gate ──────────────────────────────────────────────
+
+export interface PinnedExtensionEntry {
+    version: string;
+    url: string;
+}
+
+export type PinnedExtensions = Record<string, PinnedExtensionEntry>;
+
+/** Type guard to validate the PinnedExtensions structure. */
+export function isPinnedExtensions(obj: unknown): obj is PinnedExtensions {
+    if (!obj || typeof obj !== "object") {
+        return false;
+    }
+    for (const [key, value] of Object.entries(obj)) {
+        if (typeof key !== "string") {
+            return false;
+        }
+        const entry = value as Partial<PinnedExtensionEntry>;
+        if (typeof entry?.version !== "string" || typeof entry?.url !== "string") {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
+ * Reads pinnedExtensions from the local metadata.json.
+ * Returns the map if present, or undefined if absent/unreadable.
+ */
+export async function readLocalPinnedExtensions(): Promise<PinnedExtensions | undefined> {
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    if (!workspaceFolder) {
+        return undefined;
+    }
+    try {
+        const metadataUri = vscode.Uri.joinPath(workspaceFolder.uri, "metadata.json");
+        const content = await vscode.workspace.fs.readFile(metadataUri);
+        const metadata = JSON.parse(new TextDecoder().decode(content));
+        const pins = metadata?.meta?.pinnedExtensions;
+        return isPinnedExtensions(pins) ? pins : undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+/** Strip publisher prefix and -extension suffix, title-case the rest. */
+function extensionDisplayName(extensionId: string): string {
+    const name = extensionId.includes(".")
+        ? extensionId.slice(extensionId.indexOf(".") + 1)
+        : extensionId;
+    return name
+        .replace(/-extension$/, "")
+        .split("-")
+        .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+        .join(" ");
 }
 
 export function registerVersionCheckCommands(context: vscode.ExtensionContext): void {

--- a/src/utils/extensionVersionChecker.ts
+++ b/src/utils/extensionVersionChecker.ts
@@ -422,17 +422,76 @@ export function buildOutdatedExtensionsMessage(outdatedExtensions: ExtensionVers
     const names = outdatedExtensions.map((e) => e.displayName);
 
     const formatNames = (arr: string[]): string => {
-        if (arr.length <= 1) return arr[0] || "";
-        if (arr.length === 2) return `${arr[0]} and ${arr[1]}`;
+        if (arr.length <= 1) { return arr[0] || ""; }
+        if (arr.length === 2) { return `${arr[0]} and ${arr[1]}`; }
         return `${arr.slice(0, -1).join(", ")}, and ${arr[arr.length - 1]}`;
     };
 
-    if (names.length === 0) return "To sync, update:"; // safety fallback
+    if (names.length === 0) { return "To sync, update:"; } // safety fallback
     const bullets = names.map((n) => `- ${n}`).join("\n");
     return `To sync, update:\n${bullets}`;
 }
 
-async function showMetadataVersionMismatchNotification(
+// ── Pinned extension sync gate ──────────────────────────────────────────────
+
+export interface PinnedExtensionEntry {
+    version: string;
+    url: string;
+}
+
+export type PinnedExtensions = Record<string, PinnedExtensionEntry>;
+
+/** Type guard to validate the PinnedExtensions structure. */
+export function isPinnedExtensions(obj: unknown): obj is PinnedExtensions {
+    if (!obj || typeof obj !== "object") {
+        return false;
+    }
+    for (const [key, value] of Object.entries(obj)) {
+        if (typeof key !== "string") {
+            return false;
+        }
+        const entry = value as Partial<PinnedExtensionEntry>;
+        if (typeof entry?.version !== "string" || typeof entry?.url !== "string") {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
+ * Reads pinnedExtensions from the local metadata.json.
+ * Returns the map if present, or undefined if absent/unreadable.
+ */
+export async function readLocalPinnedExtensions(): Promise<PinnedExtensions | undefined> {
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    if (!workspaceFolder) {
+        return undefined;
+    }
+    try {
+        const metadataUri = vscode.Uri.joinPath(workspaceFolder.uri, "metadata.json");
+        const content = await vscode.workspace.fs.readFile(metadataUri);
+        const metadata = JSON.parse(new TextDecoder().decode(content));
+        const pins = metadata?.meta?.pinnedExtensions;
+        return isPinnedExtensions(pins) ? pins : undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+/** Strip publisher prefix and -extension suffix, title-case the rest. */
+function extensionDisplayName(extensionId: string): string {
+    const name = extensionId.includes(".")
+        ? extensionId.slice(extensionId.indexOf(".") + 1)
+        : extensionId;
+    return name
+        .replace(/-extension$/, "")
+        .split("-")
+        .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+        .join(" ");
+}
+
+export function registerVersionCheckCommands(context: vscode.ExtensionContext): void {
+
     context: vscode.ExtensionContext,
     outdatedExtensions: ExtensionVersionInfo[]
 ): Promise<boolean> {
@@ -494,6 +553,47 @@ export async function checkMetadataVersionsForSync(
     context: vscode.ExtensionContext,
     isManualSync: boolean = false
 ): Promise<boolean> {
+    // 1. Pin gate — delegate entirely to the Codex Conductor.
+    //    If the Conductor is available (current Codex build), it owns the pin check.
+    //    - Mismatches → notify and block.
+    //    - No mismatches but pins exist → return true (pins satisfied; skip requiredExtensions
+    //      entirely, since the pin takes precedence over any requiredExtensions constraint).
+    //    - No pins → fall through to the requiredExtensions check below.
+    //    If the Conductor is unavailable (older build) → fall through and rely on
+    //    requiredExtensions alone.
+    try {
+        const mismatches = await vscode.commands.executeCommand<{
+            extensionId: string;
+            pinnedVersion: string;
+            runningVersion: string | null;
+        }[]>("codex.conductor.getPinMismatches");
+
+        if (mismatches && mismatches.length > 0) {
+            const summary = mismatches.map((m) => `${m.extensionId} running=${m.runningVersion} pinned=${m.pinnedVersion}`).join(", ");
+            debug(`[PinVersionChecker] Conductor pin mismatch: ${summary}`);
+            if (shouldShowVersionModal(context, isManualSync)) {
+                const bullets = mismatches
+                    .map((m) => `- ${extensionDisplayName(m.extensionId)} (pinned to v${m.pinnedVersion})`)
+                    .join("\n");
+                const message = `Extension version pin detected — sync paused.\n${bullets}`;
+                vscode.window.showInformationMessage(message);
+            }
+            return false;
+        }
+
+        const effectivePins = await vscode.commands.executeCommand<Record<string, unknown>>(
+            "codex.conductor.getEffectivePinnedExtensions"
+        );
+        if (effectivePins && Object.keys(effectivePins).length > 0) {
+            // Pins are active and satisfied — requiredExtensions is not authoritative.
+            return true;
+        }
+    } catch {
+        // Conductor not available (older build) — fall through to requiredExtensions check.
+        debug("[PinVersionChecker] Conductor unavailable, falling back to requiredExtensions");
+    }
+
+    // 2. requiredExtensions check (no active pins).
     const result = await checkAndUpdateMetadataVersions();
 
     if (result.canSync) {

--- a/src/utils/extensionVersionChecker.ts
+++ b/src/utils/extensionVersionChecker.ts
@@ -8,20 +8,38 @@ import * as vscode from "vscode";
  * conflicts and the issues that were causing metadata.json to be deleted.
  */
 
-// Lightweight version comparator to avoid external semver dependency
+// Compare only the numeric x.y.z core. Affixes like -pr123 or -pr123-shorthash are ignored.
 export function compareVersions(a: string, b: string): number {
-    const normalize = (v: string) => v.trim().replace(/^v/i, "");
-    const parse = (v: string) => normalize(v).split(".").map((x) => parseInt(x, 10));
-    const pa = parse(a);
-    const pb = parse(b);
-    const len = Math.max(pa.length, pb.length);
-    for (let i = 0; i < len; i++) {
-        const ai = pa[i] ?? 0;
-        const bi = pb[i] ?? 0;
-        if (ai > bi) return 1;
-        if (ai < bi) return -1;
+    const pa = extractCoreVersionParts(a);
+    const pb = extractCoreVersionParts(b);
+
+    if (!pa || !pb) {
+        throw new Error(`Invalid version core: a=${a}, b=${b}`);
+    }
+
+    for (let i = 0; i < 3; i++) {
+        const ai = pa[i];
+        const bi = pb[i];
+        if (ai > bi) { return 1; }
+        if (ai < bi) { return -1; }
     }
     return 0;
+}
+
+/**
+ * Parses out the x.y.z core of a version string.
+ */
+function extractCoreVersionParts(version: string): [number, number, number] | null {
+    const match = version.trim().match(/^v?(\d+)\.(\d+)\.(\d+)/i);
+    if (!match) {
+        return null;
+    }
+
+    return [
+        parseInt(match[1], 10),
+        parseInt(match[2], 10),
+        parseInt(match[3], 10),
+    ];
 }
 
 const DEBUG_MODE = false;


### PR DESCRIPTION
This PR integrates the Codex Conductor's pin validation and admin intent mechanisms into the SCM synchronization flow to ensure extension version consistency across collaborators.

### Changes
- **Pin Sync Gate**: Implemented a synchronization gate that delegates version mismatch detection to the Codex Conductor workbench contribution.
- **Admin Intent Integration**: Added support for bypassing the sync gate when an admin has explicitly set a local pin intent, preventing redundant reloads during the push phase.
- **Robust Version Checking**: Enhanced the `requiredExtensions` validation with fail-open logic for malformed metadata and fail-closed logic for indeterminate states.
- **Pre-release Support**: Refactored version comparison to correctly handle pre-release suffixes (e.g., `-pr123`) used in PR builds.
- **SCM Flow Integration**: Integrated pin checks into the `SCMManager` to block merges and pushes when running versions are out of compliance with project metadata.

### Architecture Documentation
- [Extension Version Pinning for Codex Projects](../codex-arch/2026-03-project-extension-pinning.md)
- [Pin Enforcement Scenarios](../codex-arch/2026-03-pin-enforcement-scenarios.md)