### PR TITLE
Enhance media strategy resolution to prioritize disk settings over ca…

### DIFF
--- a/src/git/GitService.ts
+++ b/src/git/GitService.ts
@@ -1333,28 +1333,26 @@ export class GitService {
     }
 
     /**
-     * Resolve the active media strategy for a repo, falling back to disk if the
-     * in-memory `StateManager` doesn't know about this workspace yet.
+     * Resolve the active media strategy for a repo. Disk is the source of truth.
      *
-     * Why this exists: `StateManager.setRepoStrategy` is only called when the
-     * user explicitly changes strategy (StartupFlow) or finishes a clone. After
-     * a VS Code restart, the strategy map is empty until something repopulates
-     * it. If we then sync a `stream-only` project, `getRepoStrategy(dir)`
-     * returns `undefined`, the reconcile defaults to the auto-download branch,
-     * and we silently bulk-download LFS objects the user explicitly opted out
-     * of — eating disk and bandwidth they may not have.
+     * The per-machine `.project/localProjectSettings.json` is gitignored,
+     * survives restart, and is written synchronously by codex
+     * (`setMediaFilesStrategy`) whenever the user changes strategy. We read it
+     * FIRST and only fall back to the in-memory `StateManager` cache when the
+     * file is missing/unreadable (e.g. a brand-new clone before settings exist).
      *
-     * This helper plugs that hole by reading the per-machine
-     * `.project/localProjectSettings.json` (which IS the source of truth, since
-     * it's gitignored and survives restart) and caching the result back into
-     * `StateManager` so subsequent calls hit the fast path.
+     * Why disk must win over the cache: the `StateManager` strategy map is only
+     * updated via a best-effort `setRepoMediaStrategy` notification from codex,
+     * which can silently fail to land (auth API not yet available at switch
+     * time, a path-key mismatch with `dir`, or a persist race with the window
+     * reload on open). It is also persisted across restarts, so a stale
+     * `auto-download` set at clone time could survive and override a user's
+     * later switch to stream-and-save / stream-only — making reconcile bulk
+     * -download every LFS object the user explicitly opted out of. Reading disk
+     * first closes that hole, and we refresh the cache to match so other readers
+     * stay consistent for the rest of the session.
      */
     private async resolveRepoStrategy(dir: string): Promise<MediaFilesStrategy | undefined> {
-        const cached = this.stateManager.getRepoStrategy(dir);
-        if (cached !== undefined) {
-            return cached;
-        }
-
         try {
             const settingsPath = path.join(dir, ".project", "localProjectSettings.json");
             const content = await fs.promises.readFile(settingsPath, "utf8");
@@ -1363,16 +1361,25 @@ export class GitService {
                 settings?.currentMediaFilesStrategy ?? settings?.mediaFilesStrategy;
 
             if (fromDisk === "auto-download" || fromDisk === "stream-and-save" || fromDisk === "stream-only") {
-                // Cache for the rest of this session so we only do the disk read once per restart.
-                await this.stateManager.setRepoStrategy(dir, fromDisk);
-                this.debugLog(`[GitService] Loaded media strategy from disk: ${fromDisk}`);
+                // Keep the cache in sync with disk so the strategy map can never
+                // override the user's actual on-disk choice on a later read.
+                const cached = this.stateManager.getRepoStrategy(dir);
+                if (cached !== fromDisk) {
+                    await this.stateManager.setRepoStrategy(dir, fromDisk);
+                    this.debugLog(
+                        `[GitService] Media strategy from disk (${fromDisk}) overrides stale cache (${cached ?? "unset"})`
+                    );
+                } else {
+                    this.debugLog(`[GitService] Resolved media strategy from disk: ${fromDisk}`);
+                }
                 return fromDisk;
             }
         } catch {
-            // Missing settings file (e.g. brand-new clone) or parse error — fall through.
+            // Missing settings file (e.g. brand-new clone) or parse error — fall
+            // back to whatever the in-memory/persisted cache knows, if anything.
         }
 
-        return undefined;
+        return this.stateManager.getRepoStrategy(dir);
     }
 
     /**

--- a/src/test/suite/unit/mediaStrategy.resolveStrategy.test.ts
+++ b/src/test/suite/unit/mediaStrategy.resolveStrategy.test.ts
@@ -1,0 +1,131 @@
+import * as assert from "assert";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import * as dugiteGit from "../../../git/dugiteGit";
+import { StateManager } from "../../../state";
+
+suite("Unit: resolveRepoStrategy treats disk as source of truth", () => {
+    suiteSetup(() => {
+        dugiteGit.useEmbeddedGitBinary();
+    });
+
+    const makeStateManager = (): StateManager => {
+        const ctx: any = {
+            subscriptions: [],
+            globalState: { get: () => undefined, update: async () => {} },
+            workspaceState: { get: () => undefined, update: async () => {} },
+        };
+        StateManager.initialize(ctx);
+        return StateManager.getInstance();
+    };
+
+    const writeStrategyToDisk = async (dir: string, strategy: string): Promise<void> => {
+        const settingsAbs = path.join(dir, ".project", "localProjectSettings.json");
+        await fs.promises.mkdir(path.dirname(settingsAbs), { recursive: true });
+        await fs.promises.writeFile(
+            settingsAbs,
+            JSON.stringify({ currentMediaFilesStrategy: strategy }, null, 2),
+            "utf8"
+        );
+    };
+
+    test("on-disk stream-and-save overrides a stale auto-download cache", async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), "frontier-resolve-disk-"));
+        await writeStrategyToDisk(dir, "stream-and-save");
+
+        const stateManager = makeStateManager();
+        // Simulate the stale cache set at clone time (the bug condition).
+        await stateManager.setRepoStrategy(dir, "auto-download");
+
+        const { GitService } = require("../../../git/GitService");
+        const gs = new GitService(stateManager);
+
+        const resolved = await (gs as any).resolveRepoStrategy(dir);
+
+        assert.strictEqual(
+            resolved,
+            "stream-and-save",
+            "Disk strategy must win over a stale in-memory cache"
+        );
+        assert.strictEqual(
+            stateManager.getRepoStrategy(dir),
+            "stream-and-save",
+            "Cache should be refreshed to match disk"
+        );
+    });
+
+    test("falls back to cache when no settings file exists on disk", async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), "frontier-resolve-nodisk-"));
+
+        const stateManager = makeStateManager();
+        await stateManager.setRepoStrategy(dir, "stream-only");
+
+        const { GitService } = require("../../../git/GitService");
+        const gs = new GitService(stateManager);
+
+        const resolved = await (gs as any).resolveRepoStrategy(dir);
+
+        assert.strictEqual(
+            resolved,
+            "stream-only",
+            "With no settings file, the cached strategy is used as a fallback"
+        );
+    });
+
+    test("reconcile does not bulk-download when disk says stream-and-save despite stale cache", async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), "frontier-resolve-reconcile-"));
+        await dugiteGit.init(dir);
+
+        const pointerRel = ".project/attachments/pointers/audio/stream.wav";
+        const pointerAbs = path.join(dir, pointerRel);
+        await fs.promises.mkdir(path.dirname(pointerAbs), { recursive: true });
+        await fs.promises.writeFile(
+            pointerAbs,
+            [
+                "version https://git-lfs.github.com/spec/v1",
+                `oid sha256:${"d".repeat(64)}`,
+                "size 3",
+            ].join("\n"),
+            "utf8"
+        );
+
+        await dugiteGit.add(dir, pointerRel);
+        await dugiteGit.commit(dir, "add pointer", { name: "Tester", email: "tester@example.com" });
+        await dugiteGit.addRemote(dir, "origin", "https://example.com/repo.git");
+
+        // Disk = stream-and-save, but the persisted cache is the stale clone value.
+        await writeStrategyToDisk(dir, "stream-and-save");
+        const stateManager = makeStateManager();
+        await stateManager.setRepoStrategy(dir, "auto-download");
+
+        const { GitService } = require("../../../git/GitService");
+        const gs = new GitService(stateManager);
+        const originalGetRemoteUrl = gs.getRemoteUrl;
+        (gs as any).getRemoteUrl = async () => "https://example.com/repo.git";
+
+        const originalFetch = (globalThis as any).fetch;
+        (globalThis as any).fetch = async () =>
+            new Response(JSON.stringify({ objects: [] }), { status: 200 });
+
+        try {
+            await (gs as any).reconcilePointersFilesystem(dir, { username: "oauth2", password: "x" });
+
+            const filesAbs = path.join(dir, ".project/attachments/files/audio/stream.wav");
+            let exists = true;
+            try {
+                await fs.promises.access(filesAbs);
+            } catch {
+                exists = false;
+            }
+            assert.strictEqual(
+                exists,
+                false,
+                "No bulk download should happen when disk strategy is stream-and-save"
+            );
+        } finally {
+            (gs as any).getRemoteUrl = originalGetRemoteUrl;
+            (globalThis as any).fetch = originalFetch;
+        }
+    });
+});


### PR DESCRIPTION
…ched values. Introduced unit tests to verify that on-disk strategies correctly override stale in-memory caches, preventing unnecessary bulk downloads in stream-only projects. This ensures user preferences are respected and optimizes bandwidth usage.